### PR TITLE
Amended checksum URL to match new format 0.50.3+

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -84,7 +84,7 @@ purple_bold "Downloading ${url}"
 binarySha=$(curl -fsSL ${url} | tee ${filename} | ${sha256bin} | cut -b 1-64)
 
 # download the checksum
-expectedSha=$(curl ${base_url}/${product}/${version}/checksums.txt | grep ${filename} | cut -b 1-64)
+expectedSha=$(curl ${base_url}/${product}/${version}/checksums.${os}.txt | grep ${filename} | cut -b 1-64)
 
 # extract binary
 if [ $binarySha = $expectedSha ]; then


### PR DESCRIPTION
Looks like the path for the checksums file changed at 0.50.3, so I amended the URL to include the OS.

I've assumed you might have separate binaries for the BSD's and follow the same pattern?

Best Regards

Gary