### PR TITLE
improvements for linux install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -104,16 +104,21 @@ if [ $OS = "RedHat" ]; then
   purple_bold "\n* Installing the Mondoo agent package"
   $sudo_cmd yum install -y mondoo
 elif [ $OS = "Debian" ]; then
-  purple_bold "\n* Installing apt-transport-https"
-  $sudo_cmd apt-get update
-  $sudo_cmd apt-get install -y apt-transport-https ca-certificates gnupg
+  if type mondoo >nul 2>&1; then
+    purple_bold "\n* Mondoo already installed. Installing updates if available"
+    $sudo_cmd apt-get update -y && $sudo_cmd apt-get upgrade -y mondoo
+  else  
+    purple_bold "\n* Installing apt-transport-https"
+    $sudo_cmd apt-get update
+    $sudo_cmd apt-get install -y apt-transport-https ca-certificates gnupg
 
-  purple_bold "\n* Configuring APT package sources for Mondoo at /etc/apt/sources.list.d/mondoo.list"
-  curl --retry 3 --retry-delay 10 -sSL https://releases.mondoo.io/debian/pubkey.gpg | $sudo_cmd apt-key add - 
-  echo "deb https://releases.mondoo.io/debian/ stable main" | $sudo_cmd tee /etc/apt/sources.list.d/mondoo.list
+    purple_bold "\n* Configuring APT package sources for Mondoo at /etc/apt/sources.list.d/mondoo.list"
+    curl --retry 3 --retry-delay 10 -sSL https://releases.mondoo.io/debian/pubkey.gpg | $sudo_cmd apt-key add - 
+    echo "deb https://releases.mondoo.io/debian/ stable main" | $sudo_cmd tee /etc/apt/sources.list.d/mondoo.list
 
-  purple_bold "\n* Installing the Mondoo agent package"
-  $sudo_cmd apt-get update -y && $sudo_cmd apt-get install -y mondoo
+    purple_bold "\n* Installing the Mondoo agent package"
+    $sudo_cmd apt-get update -y && $sudo_cmd apt-get install -y mondoo
+  fi
 elif [ $OS = "Suse" ]; then
   purple_bold "\n* Configuring ZYPPER sources for Mondoo at /etc/zypp/repos.d/mondoo.repo"
   curl --retry 3 --retry-delay 10 -sSL https://releases.mondoo.io/rpm/mondoo.repo | $sudo_cmd tee /etc/zypp/repos.d/mondoo.repo

--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,7 @@ elif [ $OS = "Debian" ]; then
     $sudo_cmd apt-get update -y && $sudo_cmd apt-get upgrade -y mondoo
   else  
     purple_bold "\n* Installing apt-transport-https"
-    $sudo_cmd apt-get update
+    $sudo_cmd apt-get update -y
     $sudo_cmd apt-get install -y apt-transport-https ca-certificates gnupg
 
     purple_bold "\n* Configuring APT package sources for Mondoo at /etc/apt/sources.list.d/mondoo.list"


### PR DESCRIPTION
- [x] run multiple times should keep the same output
- [x] if the repo is already installed, do nothing (debian)
- [x] if the package is already installed, update it to the latest version (debian)
- [x] if the agent is already registered, do nothing

added section to debian install to check if already installed and if so only update
added guards to skip registering the agent if mondoo status exit code is 0


BEFORE, on second run:
![master](https://user-images.githubusercontent.com/10341541/99438733-6acc9380-28d1-11eb-919c-8429b5e123de.png)


AFTER, on second run:
![branch](https://user-images.githubusercontent.com/10341541/99438761-77e98280-28d1-11eb-8445-7b02096eb0f0.png)
