### PR TITLE
fix(install.ps1): removed unncessary "$" and updated syntax warning

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -46,7 +46,7 @@ function Install-Mondoo {
     $wc = New-Object Net.Webclient
     $wc.Headers.Add('User-Agent', (Get-UserAgent))
     $latest = $wc.DownloadString($url) | ConvertFrom-Json 
-    $entry = $latest.files | where { $_.platform -eq "windows" -and $_.filename -match "${filetype}$" }
+    $entry = $latest.files | Where-Object { $_.platform -eq "windows" -and $_.filename -match "${filetype}" }
     $entry.filename
   }
 
@@ -70,7 +70,7 @@ function Install-Mondoo {
   purple "
                           .-.            
                           : :            
-  ,-.,-.,-. .--. ,-.,-. .-' : .--.  .--. ™
+  ,-.,-.,-. .--. ,-.,-. .-' : .--.  .--. ™ 
   : ,. ,. :' .; :: ,. :' .; :' .; :' .; :
   :_;:_;:_;`.__.':_;:_;`.__.'`.__.'`.__.
   "
@@ -191,4 +191,4 @@ function Install-Mondoo {
   $erroractionpreference = $previous_erroractionpreference
 
   }
-}
+} 


### PR DESCRIPTION
Line 49 had an unnecessary "$" hanging, which was causing Windows installs to fail. I also updated PowerShell 

I also updated the `where` alias to `Where-Object` to address backwards compatibility:

```
  'where' is an alias of 'Where-Object'. Alias can introduce  possible problems and make scripts hard to maintain. Please consider changing alias to its full content. 
```

Signed-off-by: Scott Ford <scott@scottford.io>