### PR TITLE
Fixes issue where rhel8 is not recognized as a known distribution

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ The source code of this installer is available on Github:
 # Detect operating system
 # -----------------------
 # Store detected value in $OS
-KNOWN_DISTRIBUTION="(RedHat|CentOS|Debian|Ubuntu|openSUSE|Amazon|SUSE|Arch Linux)"
+KNOWN_DISTRIBUTION="(RedHat|Red Hat|CentOS|Debian|Ubuntu|openSUSE|Amazon|SUSE|Arch Linux)"
 DISTRIBUTION="$(
   lsb_release -d 2>/dev/null | grep -Eo "$KNOWN_DISTRIBUTION" || \
     grep -m1 -Eo "$KNOWN_DISTRIBUTION" /etc/os-release 2>/dev/null || \


### PR DESCRIPTION
This PR fixes an issue where RHEL8 is not recognized as a known distribution.

Signed-off-by: Scott Ford <scott@scottford.io>