### PR TITLE
🥳 add variable `ensure_managed_client` to ensure installed clients are managed

### DIFF
--- a/deployment/ansible-mondoo/README.md
+++ b/deployment/ansible-mondoo/README.md
@@ -58,7 +58,13 @@ This playbook demonstrates how to use the Mondoo role to install the Mondoo Clie
         registration_token: "changeme"
 ```
 
-If you do not want to re-register existing Mondoo Clients, then set `force_registration: false` in vars:
+In addition we support the following variables:
+
+| variable                      | description                                                               |
+|-------------------------------|---------------------------------------------------------------------------|
+| `force_registration: true`    | set to true if you want to re-register existing Mondoo Clients            |
+| `ensure_managed_client: true` | ensures the configured clients are configured as managed Client in Mondoo |
+
 
 ```yaml
 ---
@@ -68,7 +74,8 @@ If you do not want to re-register existing Mondoo Clients, then set `force_regis
     - role: mondoolabs.mondoo
       vars:
         registration_token: "changeme"
-        force_registration: false
+        force_registration: true
+        ensure_managed_client: true
 ```
 
 3. Run the playbook with the local hosts file

--- a/deployment/ansible-mondoo/tasks/linux.yml
+++ b/deployment/ansible-mondoo/tasks/linux.yml
@@ -67,5 +67,7 @@
   become: true
   when: not ansible_check_mode
 
-
-- name: ensure mondoo client is managed
+- name: ensure Mondoo Client is managed
+  command: mondoo register
+  become: true
+  when: ensure_managed_client == true and not ansible_check_mode

--- a/deployment/ansible-mondoo/tasks/windows.yml
+++ b/deployment/ansible-mondoo/tasks/windows.yml
@@ -34,7 +34,7 @@
   # unregisters an existing Mondoo Client if it was registered
   ansible.windows.win_command: mondoo.exe unregister --force --config C:\\ProgramData\\Mondoo\\mondoo.yml
   args:
-    chdir: "C:\\Program Files\\Mondoo\\service"
+    chdir: "C:\\Program Files\\Mondoo"
     # only run the command if no config file exists
     creates: C:\ProgramData\Mondoo\mondoo.yml
   when: force_registration == true
@@ -51,7 +51,13 @@
 - name: register Mondoo Client
   ansible.windows.win_command: mondoo.exe register --config C:\\ProgramData\\Mondoo\\mondoo.yml --token {{ registration_token }}
   args:
-    chdir: "C:\\Program Files\\Mondoo\\service"
+    chdir: "C:\\Program Files\\Mondoo"
     # only run the command if no config file exists (was not deleted in non-force mode)
     creates: C:\ProgramData\Mondoo\mondoo.yml
   when: not ansible_check_mode
+
+- name: ensure Mondoo Client is managed
+  ansible.windows.win_command: mondoo.exe register
+  args:
+    chdir: "C:\\Program Files\\Mondoo"
+  when: ensure_managed_client == true and not ansible_check_mode


### PR DESCRIPTION
You can configure to ensure all clients with service accounts become managed:

```yaml
- hosts: mondoo_hosts
  roles:
  - role: mondoolabs.mondoo
    vars:
       registration_token: "eyJhbG..zXX"
       ensure_managed_client: true
```