### PR TITLE
Updates Ansible Role to start and enable Mondoo as a service on Windows

### DIFF
--- a/deployment/ansible-mondoo/tasks/windows.yml
+++ b/deployment/ansible-mondoo/tasks/windows.yml
@@ -56,6 +56,13 @@
     creates: C:\ProgramData\Mondoo\mondoo.yml
   when: not ansible_check_mode
 
+- name: Set Mondoo startup mode to auto and ensure it is started
+  win_service:
+    name: mondoo
+    start_mode: auto
+    state: started
+  when: not ansible_check_mode
+
 - name: ensure Mondoo Client is managed
   ansible.windows.win_command: mondoo.exe register
   args:


### PR DESCRIPTION
This PR adds a new task to the `windows.yml` to `Set Mondoo startup mode to auto and ensure it is started` 

Signed-off-by: Scott Ford <scott@scottford.io>