### PR TITLE
🧹 remove outdated dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: bundler
-  directory: "/deployment/chef-mondoo"
-  schedule:
-    interval: daily
-    time: "13:00"
-  open-pull-requests-limit: 10


### PR DESCRIPTION
The chef content moved to https://github.com/mondoolabs/chef-mondoo so we do not need this here anymore