### PR TITLE
Add Docker support for ARMv6

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/386,linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/386,linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
           push: true
           build-args: VERSION=${{ steps.vars.outputs.tag }}
           tags: mondoolabs/mondoo:${{ steps.vars.outputs.tag }},mondoolabs/mondoo:latest


### PR DESCRIPTION
Mondoo 5.29.1 has added support for ARMv6, this PR adds support to our mult-architecture Docker image!