### PR TITLE
fix: workaround race condition where cnquery is partially indexed 

### DIFF
--- a/.github/workflows/pkg_published_trigger_build_release.yaml
+++ b/.github/workflows/pkg_published_trigger_build_release.yaml
@@ -130,6 +130,12 @@ jobs:
         IDX_OPTS: ${{ inputs.reindex-full && '--force-recompute' || '' }}
         SKIP: ${{ (needs.parse-inputs.outputs.skip-publish == 'true') && 'echo skipping...' || '' }}
       run: |
+          # force regenerate cnspec & cnquery artifacts.json on release, as we have a race condition with the cloud run releasr function
+          if [[ -z "$IDX_OPTS" ]]
+          then
+            $SKIP ./releasr idx gs://${{ needs.parse-inputs.outputs.bucket }} --app "cnquery/${{ steps.parse-inputs.outputs.version }}"
+            $SKIP ./releasr idx gs://${{ needs.parse-inputs.outputs.bucket }}  --app "cnquery/${{ steps.parse-inputs.outputs.version }}"
+          fi
           $SKIP ./releasr idx gs://${{ needs.parse-inputs.outputs.bucket }} $IDX_OPTS
     - name: Restart minstaller Cloud Run Service
       env:


### PR DESCRIPTION
fix workaround race condition where cnquery is partially indexed on release