### PR TITLE
debian repo key fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -432,7 +432,7 @@ configure_debian_installer() {
         else
           curl -A "${UserAgent}" --retry 3 --retry-delay 10 -sSL https://releases.mondoo.com/debian/pubkey.gpg | sudo_cmd gpg --dearmor --yes --output /usr/share/keyrings/mondoo-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/mondoo-archive-keyring.gpg] https://releases.mondoo.com/debian/ stable main" | sudo_cmd tee /etc/apt/sources.list.d/mondoo.list
-	  sudo_cmd chmod 644 /usr/share/keyrings/mondoo-archive-keyring.gpg
+          sudo_cmd chmod 644 /usr/share/keyrings/mondoo-archive-keyring.gpg
         fi
     }
 


### PR DESCRIPTION
Tries to sidestep the issue from https://github.com/mondoo-community/workspace-cid/issues/19

If the apt repo is set without the public key being added to the keyrings the first "apt update" would potentially fail. This change fixes this behavior by reverting the repo being set, so that the normal path of setting everything up can be taken. This only happens when the installer is run and the repo is already set, without cnspec already being installed.

This could also be relevant for the SUSE and RHEL installer, although I do not know if their installation fails in this scenario.