### PR TITLE
fix(install.sh): Explictly set permissions for apt-based GPG keys

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -430,8 +430,10 @@ configure_debian_installer() {
           curl -A "${UserAgent}" --retry 3 --retry-delay 10 -sSL https://releases.mondoo.com/debian/pubkey.gpg | sudo_cmd apt-key add -
           echo "deb https://releases.mondoo.com/debian/ stable main" | sudo_cmd tee /etc/apt/sources.list.d/mondoo.list
         else
-          curl -A "${UserAgent}" --retry 3 --retry-delay 10 -sSL https://releases.mondoo.com/debian/pubkey.gpg | sudo_cmd gpg --dearmor --yes --output /usr/share/keyrings/mondoo-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/mondoo-archive-keyring.gpg] https://releases.mondoo.com/debian/ stable main" | sudo_cmd tee /etc/apt/sources.list.d/mondoo.list
+          KEYRING_PATH="/usr/share/keyrings/mondoo-archive-keyring.gpg"
+          curl -A "${UserAgent}" --retry 3 --retry-delay 10 -sSL https://releases.mondoo.com/debian/pubkey.gpg | sudo_cmd gpg --dearmor --yes --output "${KEYRING_PATH}"
+          sudo_cmd chmod 0644 "${KEYRING_PATH}"
+          echo "deb [signed-by=${KEYRING_PATH}] https://releases.mondoo.com/debian/ stable main" | sudo_cmd tee /etc/apt/sources.list.d/mondoo.list
         fi
     }
 


### PR DESCRIPTION
Fixes https://github.com/mondoohq/installer/issues/605