### PR TITLE
Add -p flag for customizing providers_url at install-time

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -595,7 +595,8 @@ configure_login_cmd() {
   # If a custom providers URL is not set via the -p flag, and this is not a
   # standard installation, set the default providers URL. This check is
   # designed to be modified by a server-side replacement for on-premise installers.
-  if [ -z "$PROVIDERS_URL" ] && [[ ! "https://releases.mondoo.com" =~ releases\.mondoo\.com ]]; then
+  RELEASES_URL="https://releases.mondoo.com"
+  if [ -z "$PROVIDERS_URL" ] && [[ ! "$RELEASES_URL" =~ releases\.mondoo\.com ]]; then
     echo "Overriding providers URL"
     PROVIDERS_URL="https://releases.mondoo.com/providers/"
   fi


### PR DESCRIPTION
1. Add a `-p <providers_url>` flag that adds the ability to customize the `providers_url` written to the mondoo config file at install time, e.g.

`bash -c "$(curl https://install.mondoo.com/sh)" -- -t <MONDOO_TOKEN> -p <PROVIDERS_URL_OVERRIDE>`

2. Additionally, there is new templated condition that will be automatically rewritten by hosted mInstaller instances so that the `providers_url` is automatically set for hosted instances.

3. Inline the RPM repo config instead of fetching it from releases, for better robustness (no external dependency / curl), as well as leverage the above mentioned rewriting capability in mInstaller. This mirrors the behaviour for dpkg repo configs which are already inlined.

4. Remove duplicate `configure_linux_token()` declaration