### PR TITLE
Adding retry logic manually as the action doesn't support it

### DIFF
--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -137,7 +137,7 @@ jobs:
 
             for attempt in $(seq 1 $max_attempts); do
               echo "Attempt $attempt of $max_attempts: Downloading $filename"
-              if curl -sSL --connect-timeout 30 --max-time 300 --retry 3 --retry-delay 5 \
+              if curl -sSL --fail-with-body --connect-timeout 30 --max-time 300 --retry 3 --retry-delay 5 \
                 -H "Authorization: token $GITHUB_TOKEN" \
                 -H "Accept: application/octet-stream" \
                 -o "$filename" \


### PR DESCRIPTION
**Summary**

 This change attempted to resolve a couple of recent workflow errors.  They both errored due to not being able to connect to a remote endpoint.  

  - Enhanced download reliability by adding retry logic with exponential backoff to curl commands
  - Enhanced error handling and validation for binary extraction steps
  - Enabled dependency caching in the trusted signing action to improve workflow performance
  - Added SHA256 checksum verification for downloaded binaries to ensure integrity and authenticity (Previous TODO)

  **Test plan**

  - Verify the workflow runs successfully with retry logic during network issues
  - Confirm binary downloads complete when GitHub releases return redirects
  - Validate checksum verification correctly detects tampered or corrupted downloads
  - Test that extraction failures properly fail the build
  - Validate signed MSI packages are created correctly
  - Check workflow performance improvements from caching

Here is the final test run...

https://github.com/mondoohq/installer/actions/runs/21177175843/job/60909102377