### PR TITLE
Added call to clear the minstaller cache that fails open

### DIFF
--- a/.github/workflows/test-released-install-ps1.yaml
+++ b/.github/workflows/test-released-install-ps1.yaml
@@ -31,6 +31,20 @@ jobs:
           command: |
             vSEMVER=${{ inputs.version }}
             SEMVER="${vSEMVER//v}"
+
+            # Clear cache before checking (ignore failures)
+            echo "Clearing minstaller's cache..."
+            cache_response=$(curl -s -w "HTTP_CODE:%{http_code}" \
+              -X POST https://install.mondoo.com/_/cache/clear-all \
+              -H "X-API-Key: ${{ secrets.MINSTALLER_API_KEY }}" 2>/dev/null || true)
+
+            if echo "$cache_response" | grep -q "HTTP_CODE:200"; then
+              echo "✅ Cache cleared successfully"
+            else
+              echo "⚠️ Cache clear failed, continuing anyway..."
+            fi
+
+            # Check if package is available
             curl -o /dev/null -s -w "%{http_code}\n" "https://install.mondoo.com/package/mondoo/windows/amd64/msi/${SEMVER}/sha256" | grep 200
 
   install-ps1-windows:

--- a/.github/workflows/test-released-install-sh.yaml
+++ b/.github/workflows/test-released-install-sh.yaml
@@ -16,8 +16,40 @@ on:
         default: "11.0.0"
 
 jobs:
+  wait-for-pkg:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for packages to be published (Release Event)
+        id: check_release_file
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          retry_wait_seconds: 20
+          timeout_seconds: 5
+          max_attempts: 100
+          retry_on: error
+          # error on HTTP code different to 200
+          command: |
+            vSEMVER=${{ inputs.version }}
+            SEMVER="${vSEMVER//v}"
+
+            # Clear cache before checking (ignore failures)
+            echo "Clearing minstaller's cache..."
+            cache_response=$(curl -s -w "HTTP_CODE:%{http_code}" \
+              -X POST https://install.mondoo.com/_/cache/clear-all \
+              -H "X-API-Key: ${{ secrets.MINSTALLER_API_KEY }}" 2>/dev/null || true)
+
+            if echo "$cache_response" | grep -q "HTTP_CODE:200"; then
+              echo "✅ Cache cleared successfully"
+            else
+              echo "⚠️ Cache clear failed, continuing anyway..."
+            fi
+
+            # Check if package is available
+            curl -o /dev/null -s -w "%{http_code}\n" "https://install.mondoo.com/package/mondoo/linux/amd64/deb/${SEMVER}/sha256" | grep 200
+
   install-sh-apt:
     runs-on: ubuntu-latest
+    needs: wait-for-pkg
     strategy:
       fail-fast: false
       matrix:
@@ -46,6 +78,7 @@ jobs:
 
   install-sh-yum:
     runs-on: ubuntu-latest
+    needs: wait-for-pkg
     strategy:
       fail-fast: false
       matrix:
@@ -79,6 +112,7 @@ jobs:
 
   install-sh-zypper:
     runs-on: ubuntu-latest
+    needs: wait-for-pkg
     strategy:
       fail-fast: false
       matrix:
@@ -102,6 +136,7 @@ jobs:
 
   install-sh-macos:
     runs-on: macos-latest
+    needs: wait-for-pkg
     strategy:
       matrix:
         os: ["macos-latest"]


### PR DESCRIPTION
This PR adds a call to clear the cache in the minstaller program that manages install.mondoo.com.

In the past, this cache has caught us out and caused release failures. Clearing it should reduce false positives and make releases smoother.

✅ Confirmed windows workflow works as expected .... https://github.com/mondoohq/installer/actions/runs/21292169526/job/61288403463
✅ Confirmed linux test workflow works as expected...
https://github.com/mondoohq/installer/actions/runs/21292254449/job/61288704597

```
Run nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
Attempt 1
  Clearing minstaller's cache...
  ✅ Cache cleared successfully
  200
  Command completed after 1 attempt(s).
  ```