### PR TITLE
fix: handle multiple Mondoo registry entries in installer

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -265,9 +265,9 @@ function Install-Mondoo {
     $Apps = @()
     $Apps += Get-ItemProperty "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*" # 32 Bit
     $Apps += Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*" # 64 Bit
-    $installed_version = $Apps | where-object Publisher -eq "Mondoo, Inc."
+    $installed_version = $Apps | where-object Publisher -eq "Mondoo, Inc." | Select-Object -Last 1
     if ($installed_version) {
-      $installed_version.version = $installed_version.DisplayVersion
+      $installed_version | Add-Member -NotePropertyName version -NotePropertyValue $installed_version.DisplayVersion -Force
     }
 
     $arch = 'amd64'

--- a/powershell/Mondoo.Installer/Mondoo.Installer.psm1
+++ b/powershell/Mondoo.Installer/Mondoo.Installer.psm1
@@ -251,9 +251,9 @@ function Install-Mondoo {
   $Apps = @()
   $Apps += Get-ItemProperty "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*" # 32 Bit
   $Apps += Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*" # 64 Bit
-  $installed_version = $Apps | where-object Publisher -eq "Mondoo, Inc."
+  $installed_version = $Apps | where-object Publisher -eq "Mondoo, Inc." | Select-Object -Last 1
   if ($installed_version){
-    $installed_version.version = $installed_version.DisplayVersion
+    $installed_version | Add-Member -NotePropertyName version -NotePropertyValue $installed_version.DisplayVersion -Force
   }
 
   $arch = 'amd64'


### PR DESCRIPTION
## Summary
- When multiple "Mondoo, Inc." entries exist in the Windows uninstall registry, `Where-Object` returns an array instead of a single object
- Property assignment on an array fails with: `The property 'Version' cannot be found on this object`
- Fix: add `Select-Object -Last 1` to ensure a single object, and use `Add-Member -Force` to safely set the version property

Fixes #662

## Test plan
- [x] Test on Windows with a single Mondoo installation
- [x] Test on Windows with multiple Mondoo registry entries (e.g. stale uninstall entries from previous installs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)