### PR TITLE
improve error handling during re-registration

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -350,11 +350,13 @@ function Install-Mondoo {
       }
 
       If (![string]::IsNullOrEmpty($RegistrationToken)) {
+        $configPath = "C:\ProgramData\Mondoo\mondoo.yml"
+
         # Prepare cnspec logout command
-        $logout_params = @("logout", "--config", "C:\ProgramData\Mondoo\mondoo.yml", "--force")
+        $logout_params = @("logout", "--config", $configPath, "--force")
 
         # Prepare cnspec login command
-        $login_params = @("login", "-t", "$RegistrationToken", "--config", "C:\ProgramData\Mondoo\mondoo.yml")
+        $login_params = @("login", "-t", "$RegistrationToken", "--config", $configPath)
         If (![string]::IsNullOrEmpty($Proxy)) {
           $login_params = $login_params + @("--api-proxy", "$Proxy")
         }
@@ -377,26 +379,55 @@ function Install-Mondoo {
         $backupErrorActionPreference = $ErrorActionPreference
         $ErrorActionPreference = "Continue"
 
-        # Logout if already cnspec client registred in
-        If ((Test-Path -Path "C:\ProgramData\Mondoo\mondoo.yml")) {
+        # Logout if already cnspec client registered
+        If ((Test-Path -Path $configPath)) {
           info " * $Product Client is already registered. Logging out and back in again to update the registration"
           $output = (& $program $logout_params 2>&1)
+          $logoutExitCode = $LASTEXITCODE
           info "$output"
-          Remove-Item "C:\ProgramData\Mondoo\mondoo.yml" -Force
+          if ($logoutExitCode -ne 0) {
+            info " * Warning: cnspec logout exited with code $logoutExitCode"
+          }
+          # Back up the config before removing it so we can restore on login failure
+          Copy-Item $configPath "$configPath.bak" -Force
+          Remove-Item $configPath -Force
         }
 
         info " * Register $Product Client"
 
         # Login to register cnspec client
         $output = (& $program $login_params 2>&1)
+        $loginExitCode = $LASTEXITCODE
 
         # Restore the error action preference
         $ErrorActionPreference = $backupErrorActionPreference
 
-        if ($output -match "ERROR") {
-          throw $output
+        $loginFailed = $false
+        if ($loginExitCode -ne 0) {
+          $loginFailed = $true
         }
-        elseif ($output) {
+        elseif ($output -match "ERROR") {
+          $loginFailed = $true
+        }
+        elseif (!(Test-Path -Path $configPath)) {
+          $loginFailed = $true
+        }
+
+        if ($loginFailed) {
+          # Restore the backup config so the system is not left without a config
+          if (Test-Path -Path "$configPath.bak") {
+            info " * Login failed. Restoring previous mondoo.yml from backup."
+            Copy-Item "$configPath.bak" $configPath -Force
+            Remove-Item "$configPath.bak" -Force
+          }
+          throw "cnspec login failed: $output"
+        }
+
+        # Login succeeded — clean up backup and report
+        if (Test-Path -Path "$configPath.bak") {
+          Remove-Item "$configPath.bak" -Force
+        }
+        if ($output) {
           info "$output"
         }
         else {

--- a/install.ps1
+++ b/install.ps1
@@ -194,6 +194,9 @@ function Install-Mondoo {
       # Build scheduled task components
       $action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument $taskArgument
       $trigger = New-ScheduledTaskTrigger -Daily -DaysInterval $Interval -At $Time
+      if (![string]::IsNullOrEmpty($Splay)) {
+        $trigger.RandomDelay = "PT${Splay}M"
+      }
       $principal = New-ScheduledTaskPrincipal -GroupId "NT AUTHORITY\SYSTEM" -RunLevel Highest
       $settings = New-ScheduledTaskSettingsSet -Compatibility Win8
 

--- a/install.ps1
+++ b/install.ps1
@@ -350,7 +350,7 @@ function Install-Mondoo {
       }
 
       If (![string]::IsNullOrEmpty($RegistrationToken)) {
-        $configPath = "C:\ProgramData\Mondoo\mondoo.yml"
+        $configPath = 'C:\ProgramData\Mondoo\mondoo.yml'
 
         # Prepare cnspec logout command
         $logout_params = @("logout", "--config", $configPath, "--force")
@@ -390,7 +390,13 @@ function Install-Mondoo {
           }
           # Back up the config before removing it so we can restore on login failure
           Copy-Item $configPath "$configPath.bak" -Force
+          if (!(Test-Path -Path "$configPath.bak")) {
+            fail "Failed to create backup of $configPath — aborting re-registration to protect existing config"
+          }
           Remove-Item $configPath -Force
+          if (Test-Path -Path $configPath) {
+            fail "Failed to remove $configPath — aborting re-registration to avoid ambiguous state"
+          }
         }
 
         info " * Register $Product Client"

--- a/install.ps1
+++ b/install.ps1
@@ -195,7 +195,12 @@ function Install-Mondoo {
       $action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument $taskArgument
       $trigger = New-ScheduledTaskTrigger -Daily -DaysInterval $Interval -At $Time
       if (![string]::IsNullOrEmpty($Splay)) {
-        $trigger.RandomDelay = "PT${Splay}M"
+        $splayInt = 0
+        if ([int]::TryParse($Splay, [ref]$splayInt) -and $splayInt -gt 0) {
+          $trigger.RandomDelay = "PT${splayInt}M"
+        } else {
+          info " * Warning: Invalid Splay value '$Splay' — expected a positive integer (minutes). Skipping random delay."
+        }
       }
       $principal = New-ScheduledTaskPrincipal -GroupId "NT AUTHORITY\SYSTEM" -RunLevel Highest
       $settings = New-ScheduledTaskSettingsSet -Compatibility Win8


### PR DESCRIPTION
### Summary                                                                                                                                                                                  

  - Backs up mondoo.yml to mondoo.yml.bak before deletion during re-registration, and restores it automatically if cnspec login fails                                                      
  - Adds $LASTEXITCODE checks on both cnspec logout and cnspec login commands — previously only the output string was checked for "ERROR", which misses crashes, network timeouts, and
  non-zero exits without that keyword                                                                                                                                                      
  - Adds a file existence check after login to catch cases where login reports success but produces no config file
                                                                                                                                                                                           
###   Problem                                                   
                                                                                                                                                                                           
  Since commit b177c0c ("add reregister feature", Dec 2023), running the installer with a -RegistrationToken on a system that already has mondoo.yml triggers a logout → delete → login    
  cycle. If cnspec login fails for any reason (network issue, invalid token, API outage, DNS failure), the config file is already gone with no way to recover. This leaves the agent
  unregistered and unable to communicate with the platform until someone manually re-registers.                                                                                            
                                                            
  The risk was increased by commit c930408 (Jan 2024), which removed the error check on the logout command — meaning a failed logout followed by a failed login still deleted the config.  
   
  This also runs on every installer invocation with a token, even when the installed version is already current, so scheduled updater tasks can trigger this path repeatedly.              
                                                            
###   Test plan                                                                                                                                                                                
                                                            
  - Run installer with valid token on a system with existing mondoo.yml — should logout, re-register, and clean up .bak ✅                                                                   
  - Run installer with invalid token on a system with existing mondoo.yml — should fail login, restore .bak to mondoo.yml, and throw ✅
  - Run installer with valid token on a system with no existing mondoo.yml — should register normally with no backup/restore logic     ✅                                                    
  - Simulate network failure during login (e.g. block api.mondoo.com) — should restore .bak and throw                                                                                      
  - Verify mondoo.yml.bak is not left behind after successful re-registration ✅





Also:

Add random delay for windows update scheduled task