### PR TITLE
fix: grant contents write permission for release asset uploads

### DIFF
--- a/.github/workflows/release_mondoo_pkgs.yaml
+++ b/.github/workflows/release_mondoo_pkgs.yaml
@@ -55,7 +55,7 @@ permissions: {}
 jobs:
   build-mondoo-payloads:
     permissions:
-      contents: read
+      contents: write
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ inputs.version }}


### PR DESCRIPTION
## Summary
- The recent permissions hardening (`fc38cc6`) set `contents: read` on the `build-mondoo-payloads` job in `release_mondoo_pkgs.yaml`, but `softprops/action-gh-release` requires `contents: write` to upload assets to GitHub releases.
- This caused the [v13.3.0 release workflow](https://github.com/mondoohq/installer/actions/runs/23791624123/job/69328417145) to fail with `Resource not accessible by integration`.
- Fixes the permission from `read` to `write` for that job. The other workflow using this action (`gh-release.yml`) already has `contents: write`.

## Test plan
- [ ] Trigger a test release and verify assets are uploaded to the GitHub release page

🤖 Generated with [Claude Code](https://claude.com/claude-code)