### PR TITLE
fix: grant contents write in caller workflow for reusable workflow

### DIFF
--- a/.github/workflows/pkg_published_trigger_build_release.yaml
+++ b/.github/workflows/pkg_published_trigger_build_release.yaml
@@ -32,7 +32,7 @@ on:
         type: boolean
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 env:

--- a/.github/workflows/pkg_published_trigger_build_release.yaml
+++ b/.github/workflows/pkg_published_trigger_build_release.yaml
@@ -32,7 +32,7 @@ on:
         type: boolean
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 env:
@@ -97,6 +97,8 @@ jobs:
       skip-publish: ${{ needs.parse-inputs.outputs.skip-publish == 'true' }}
       bucket: ${{ needs.parse-inputs.outputs.bucket }}
   build-mondoo-pkgs:
+    permissions:
+      contents: write
     uses: ./.github/workflows/release_mondoo_pkgs.yaml
     needs: [check-version, parse-inputs]
     secrets:


### PR DESCRIPTION
## Summary
- `pkg_published_trigger_build_release.yaml` calls `release_mondoo_pkgs.yaml` as a reusable workflow
- For reusable workflows, the caller's permissions are the ceiling — the called workflow cannot escalate beyond them
- The caller had `contents: read`, but the called workflow now needs `contents: write` (fixed in #680), causing a `startup_failure`
- Upgrades the caller's permission from `contents: read` to `contents: write`

## Test plan
- [ ] Trigger a `workflow_dispatch` run of "PKG: Package, Release, Reindex" and verify it starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)