### PR TITLE
fix: update github-actions-deploy-aur to v4.1.2

### DIFF
--- a/.github/workflows/pkg_arch-aur.yaml
+++ b/.github/workflows/pkg_arch-aur.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Publish mql AUR package
         if: ${{ !inputs.skip }}
         continue-on-error: true
-        uses: KSXGitHub/github-actions-deploy-aur@2ac5a4c1d7035885d46b10e3193393be8460b6f1 # v4.1.1
+        uses: KSXGitHub/github-actions-deploy-aur@abe8ac26b51011c88be58c8809fd2ac674068ea5 # v4.1.2
         with:
           pkgname: mql
           pkgbuild: packages/archlinux/mql/PKGBUILD
@@ -74,7 +74,7 @@ jobs:
       - name: Publish cnspec AUR package
         if: ${{ !inputs.skip }}
         continue-on-error: true
-        uses: KSXGitHub/github-actions-deploy-aur@2ac5a4c1d7035885d46b10e3193393be8460b6f1 # v4.1.1
+        uses: KSXGitHub/github-actions-deploy-aur@abe8ac26b51011c88be58c8809fd2ac674068ea5 # v4.1.2
         with:
           pkgname: cnspec
           pkgbuild: packages/archlinux/cnspec/PKGBUILD
@@ -87,7 +87,7 @@ jobs:
       - name: Publish mondoo AUR package
         if: ${{ !inputs.skip }}
         continue-on-error: true
-        uses: KSXGitHub/github-actions-deploy-aur@2ac5a4c1d7035885d46b10e3193393be8460b6f1 # v4.1.1
+        uses: KSXGitHub/github-actions-deploy-aur@abe8ac26b51011c88be58c8809fd2ac674068ea5 # v4.1.2
         with:
           pkgname: mondoo
           pkgbuild: packages/archlinux/mondoo/PKGBUILD


### PR DESCRIPTION
## Summary
- Updates `KSXGitHub/github-actions-deploy-aur` from v4.1.1 (`2ac5a4c`) to v4.1.2 (`abe8ac2`)
- v4.1.1's entrypoint uses `bash --command` which is not a valid bash option — newer Arch Linux base images reject it, causing the AUR publish steps to silently fail (the steps have `continue-on-error: true`)
- v4.1.2 switches to `su -u <USER> -- <COMMAND>` which is the recommended approach

## Test plan
- [ ] Re-run the arch AUR release workflow and verify the publish steps succeed
- [ ] Verify mql, cnspec, and mondoo packages are published to AUR

🤖 Generated with [Claude Code](https://claude.com/claude-code)