### PR TITLE
chore: migrate create-github-app-token from app-id to client-id

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -55,9 +55,9 @@ jobs:
       # fetch a token for the mondoo-mergebot app
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
           private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
       - name: Release
         id: release

--- a/.github/workflows/pkg_published_trigger_build_release.yaml
+++ b/.github/workflows/pkg_published_trigger_build_release.yaml
@@ -137,9 +137,9 @@ jobs:
       # fetch a token for the mondoo-mergebot app
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
           private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
           owner: mondoohq
           repositories: |


### PR DESCRIPTION
## Summary
- Replace deprecated `app-id` input with `client-id` for `actions/create-github-app-token`
- Pin action to `v3.1.1` (`1b10c78c7865c340bc4f6099eb2f838309f1e8c3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)