### PR TITLE
chore: migrate create-github-app-token from app-id to client-id

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -55,9 +55,9 @@ jobs:
       # fetch a token for the mondoo-mergebot app
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
           private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
       - name: Release
         id: release

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -57,6 +57,8 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
+          # client-id accepts the same value as the old app-id input, see
+          # https://github.com/actions/create-github-app-token/blob/v3.1.1/main.js#L21
           client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
           private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
       - name: Release

--- a/.github/workflows/pkg_published_trigger_build_release.yaml
+++ b/.github/workflows/pkg_published_trigger_build_release.yaml
@@ -139,6 +139,8 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
+          # client-id accepts the same value as the old app-id input, see
+          # https://github.com/actions/create-github-app-token/blob/v3.1.1/main.js#L21
           client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
           private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
           owner: mondoohq

--- a/.github/workflows/pkg_published_trigger_build_release.yaml
+++ b/.github/workflows/pkg_published_trigger_build_release.yaml
@@ -137,9 +137,9 @@ jobs:
       # fetch a token for the mondoo-mergebot app
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
           private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
           owner: mondoohq
           repositories: |


### PR DESCRIPTION
## Summary
- Replace deprecated `app-id` input with `client-id` for `actions/create-github-app-token`
- Pin action to `v3.1.1` (`1b10c78c7865c340bc4f6099eb2f838309f1e8c3`)

## Why the secret name (`MONDOO_MERGEBOT_APP_ID`) is intentionally unchanged

The `client-id` input introduced in [actions/create-github-app-token#353](https://github.com/actions/create-github-app-token/pull/353) is **not** a new parameter that requires a different secret value. It is a **pure rename** of the `app-id` input. The same secret value works for both inputs.

This is confirmed by the upstream source code at v3.1.1:

**[`main.js#L21-L24`](https://github.com/actions/create-github-app-token/blob/v3.1.1/main.js#L21-L24)** — Both inputs are interchangeable:
```js
const clientId = core.getInput("client-id") || core.getInput("app-id");
if (!clientId) {
  throw new Error(
    "The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string..."
  );
}
```

**[`lib/main.js#L72-L75`](https://github.com/actions/create-github-app-token/blob/v3.1.1/lib/main.js#L72-L75)** — The value is passed as `appId` (unchanged) to `@octokit/auth-app`:
```js
const auth = createAppAuth({
  appId: clientId,
  privateKey,
  request,
});
```

There is no transformation, validation, or type check between the input and `createAppAuth`. The numeric App ID that `MONDOO_MERGEBOT_APP_ID` contains is passed directly as `appId` to `@octokit/auth-app`, exactly as before. Renaming the secret would be purely cosmetic and is not required for correctness.

**This has been verified in production** — an identical change in another repository successfully generated and used a GitHub App token in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)