### PR TITLE
fix: add timeout to cnspec status check to prevent install script hang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -542,10 +542,21 @@ configure_cloudshell_installer() {
 # --------------------
 
 detect_mondoo_registered() {
-  if [ "$(
-    ${MONDOO_BINARY_PATH} status >/dev/null 2>&1
-    echo $?
-  )" -eq "0" ]; then
+  ${MONDOO_BINARY_PATH} status >/dev/null 2>&1 &
+  _status_pid=$!
+  _elapsed=0
+  while kill -0 "$_status_pid" 2>/dev/null; do
+    if [ "$_elapsed" -ge 10 ]; then
+      kill "$_status_pid" 2>/dev/null
+      wait "$_status_pid" 2>/dev/null
+      MONDOO_IS_REGISTERED=false
+      return
+    fi
+    sleep 1
+    _elapsed=$((_elapsed + 1))
+  done
+  wait "$_status_pid"
+  if [ $? -eq 0 ]; then
     MONDOO_IS_REGISTERED=true
   else
     MONDOO_IS_REGISTERED=false


### PR DESCRIPTION
## Summary
- Adds a 10-second timeout to the `detect_mondoo_registered()` function's `cnspec status` call
- Uses a portable POSIX shell pattern (background process + poll + kill) so it works on both Linux and macOS
- If the check times out, it treats the result as "not registered" — the UI hint still displays and the script exits cleanly

## Context
When installing behind a corporate proxy without a registration token (installer.mondoo.telekom.de), no mondoo.yml is created, so cnspec status has no proxy config and hangs indefinitely trying to reach the Mondoo API. This caused the install script to appear stuck after printing the final success message.

Fixes #694

## Test plan
- [ ] Install with a registration token — verify registration detection still works
- [ ] Install without a registration token on a machine with direct internet — verify script completes and shows the hint
- [ ] Install without a registration token behind a proxy (no mondoo.yml) — verify script exits within ~10s instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
