### PR TITLE
ci: open PR from sign workflow without auto-merge

### DIFF
--- a/.github/workflows/sign_powershell.yml
+++ b/.github/workflows/sign_powershell.yml
@@ -155,4 +155,4 @@ jobs:
         if: ${{ inputs.skip-publish == false && inputs.use-test-cert == false && steps.cpr.outputs.pull-request-number != '' }}
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: gh pr merge --squash --auto --delete-branch ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge --squash --delete-branch ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
## Summary
- Removes `--auto` from the `gh pr merge` step in the Sign PowerShell Scripts workflow.
- Repo-level auto-merge is disabled (`allow_auto_merge: false`), so `--auto` was failing with `GraphQL: Auto merge is not allowed for this repository`.
- The merge step will now attempt an immediate squash merge instead.

## Notes
- If `main` branch protection requires status checks or restricts who can push, the immediate merge will still fail. In that case, either:
  1. Enable repo-level auto-merge and restore `--auto`, or
  2. Grant the mergebot app a bypass on the `main` branch protection rule.

## Test plan
- [ ] Trigger the Sign PowerShell Scripts workflow and confirm the merge step succeeds (or surfaces a clearer error than the auto-merge GraphQL one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)