### PR TITLE
ci: have pr-review-app approve sign-workflow PR before merge

### DIFF
--- a/.github/workflows/sign_powershell.yml
+++ b/.github/workflows/sign_powershell.yml
@@ -151,6 +151,20 @@ jobs:
             powershell/Mondoo.Installer/Mondoo.Installer.psm1
             powershell/Mondoo.Installer/Mondoo.Installer.psd1
 
+      - name: Generate review-bot token
+        id: generate-review-token
+        if: ${{ inputs.skip-publish == false && inputs.use-test-cert == false && steps.cpr.outputs.pull-request-number != '' }}
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.MONDOO_PR_REVIEW_APP_ID }}
+          private-key: ${{ secrets.MONDOO_PR_REVIEW_APP_PRIVATE_KEY }}
+
+      - name: Approve PR
+        if: ${{ inputs.skip-publish == false && inputs.use-test-cert == false && steps.cpr.outputs.pull-request-number != '' }}
+        env:
+          GH_TOKEN: ${{ steps.generate-review-token.outputs.token }}
+        run: gh pr review --approve ${{ steps.cpr.outputs.pull-request-number }}
+
       - name: Merge PR
         if: ${{ inputs.skip-publish == false && inputs.use-test-cert == false && steps.cpr.outputs.pull-request-number != '' }}
         env:


### PR DESCRIPTION
## Summary
- The org-level mondoo-base-policy ruleset on main requires one approving review, which blocked PR #698 (the auto-opened sign-powershell PR).
- Add a step to generate a token for the mondoo-pr-review-app (already on the ruleset bypass list and now installed on this repo) and approve the PR with it before mergebot squashes.

Requires repo secrets: MONDOO_PR_REVIEW_APP_ID, MONDOO_PR_REVIEW_APP_PRIVATE_KEY.

## Test plan
- [ ] Trigger the Sign PowerShell Scripts workflow via workflow_dispatch and confirm:
  - The auto-opened PR is approved by mondoo-pr-review-app.
  - The merge step succeeds without --auto or --admin.

Generated with Claude Code
