### PR TITLE
ci: open sign PR with GITHUB_TOKEN, mergebot approves and merges

### DIFF
--- a/.github/workflows/sign_powershell.yml
+++ b/.github/workflows/sign_powershell.yml
@@ -136,7 +136,6 @@ jobs:
         if: ${{ inputs.skip-publish == false && inputs.use-test-cert == false }}
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
-          token: ${{ steps.generate-token.outputs.token }}
           sign-commits: true
           commit-message: "Sign powershell scripts"
           title: "Sign powershell scripts"
@@ -151,18 +150,10 @@ jobs:
             powershell/Mondoo.Installer/Mondoo.Installer.psm1
             powershell/Mondoo.Installer/Mondoo.Installer.psd1
 
-      - name: Generate review-bot token
-        id: generate-review-token
-        if: ${{ inputs.skip-publish == false && inputs.use-test-cert == false && steps.cpr.outputs.pull-request-number != '' }}
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        with:
-          client-id: ${{ secrets.MONDOO_PR_REVIEW_APP_ID }}
-          private-key: ${{ secrets.MONDOO_PR_REVIEW_APP_PRIVATE_KEY }}
-
       - name: Approve PR
         if: ${{ inputs.skip-publish == false && inputs.use-test-cert == false && steps.cpr.outputs.pull-request-number != '' }}
         env:
-          GH_TOKEN: ${{ steps.generate-review-token.outputs.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: gh pr review --approve ${{ steps.cpr.outputs.pull-request-number }}
 
       - name: Merge PR


### PR DESCRIPTION
## Summary
- mondoo-pr-review-app only has pull_requests:write, so its approval did not count toward the required-review rule on the mondoo-base-policy ruleset (PR #701 was approved but stayed REVIEW_REQUIRED / BLOCKED).
- mondoo-mergebot has contents:write, so its approval does count.
- Open the PR with the default GITHUB_TOKEN (github-actions[bot] author), then have mergebot approve and merge. Different identities means no self-approval block.

## Trade-off
- PRs opened with GITHUB_TOKEN do not trigger downstream workflows. CLA/license/lint/PowerShell-test checks will not run on the auto-opened PR. None of those are required by the ruleset, so the merge is not blocked. They will still run on main after merge.

## Test plan
- [ ] Trigger the Sign PowerShell Scripts workflow via workflow_dispatch and confirm:
  - PR opens authored by github-actions[bot].
  - Mergebot's approving review counts (reviewDecision becomes APPROVED).
  - Merge step succeeds without --auto or --admin.

Generated with Claude Code
