### PR TITLE
ci: skip sign workflow when triggered by its own merge commit

### DIFF
--- a/.github/workflows/sign_powershell.yml
+++ b/.github/workflows/sign_powershell.yml
@@ -50,6 +50,8 @@ jobs:
     name: Sign PowerShell scripts
     runs-on: windows-2025
     environment: prod
+    # Skip the recursive trigger from this workflow's own merge commits.
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'Sign powershell scripts') }}
     steps:
       - name: Dump all inputs
         env:


### PR DESCRIPTION
## Summary
- The merge of the auto-opened "Sign powershell scripts" PR pushes to main, matches the workflow's path filter on .ps1/.psm1/.psd1, and re-triggers the workflow. PRs #704, #705, #706 were the resulting loop.
- Add a job-level if guard that skips push runs whose head commit message starts with "Sign powershell scripts". workflow_dispatch runs are unaffected.

## Test plan
- [ ] Manually trigger the workflow via workflow_dispatch and confirm it runs and merges a PR.
- [ ] Confirm the resulting push to main does not re-trigger the workflow (the new run is skipped at the job-level if).

Generated with Claude Code
