### PR TITLE
ci: disable failing cnquery -> mql upgrade tests

### DIFF
--- a/.github/workflows/test-released-archlinux.yaml
+++ b/.github/workflows/test-released-archlinux.yaml
@@ -68,29 +68,30 @@ jobs:
                     cnspec version | grep -q ${{ steps.version.outputs.version }} && \
                     cnquery version | grep -q ${{ steps.version.outputs.version }}"
 
-  arch-upgrade-cnquery-to-mql:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: Version
-        id: version
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      - name: Upgrade cnquery -> mql with MakePKG on Arch Linux
-        run: |
-          docker run --rm -v $(pwd):/work -w /work archlinux:latest \
-          bash -c "pacman -Syu --noconfirm && \
-                    pacman -S --noconfirm base-devel git && \
-                    cd /tmp && \
-                    useradd -m test && \
-                    echo \"test ALL=(ALL) NOPASSWD: ALL\" >> /etc/sudoers && \
-                    su test -c \"git clone https://aur.archlinux.org/cnquery && cd cnquery && makepkg\" && \
-                    cd cnquery && pacman -U --noconfirm cnquery-*.zst && cd /tmp && \
-                    cnquery version && \
-                    su test -c \"git clone https://aur.archlinux.org/mql && cd mql && makepkg\" && \
-                    cd mql && pacman -U --noconfirm mql-*.zst && \
-                    mql version | grep -q ${{ steps.version.outputs.version }} && \
-                    ! pacman -Q cnquery"
+  # TODO: re-enable once the cnquery -> mql upgrade path works on Arch Linux
+  # arch-upgrade-cnquery-to-mql:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+  #     - name: Version
+  #       id: version
+  #       env:
+  #         INPUT_VERSION: ${{ inputs.version }}
+  #       run: |
+  #         VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
+  #         echo "version=${VERSION}" >> $GITHUB_OUTPUT
+  #     - name: Upgrade cnquery -> mql with MakePKG on Arch Linux
+  #       run: |
+  #         docker run --rm -v $(pwd):/work -w /work archlinux:latest \
+  #         bash -c "pacman -Syu --noconfirm && \
+  #                   pacman -S --noconfirm base-devel git && \
+  #                   cd /tmp && \
+  #                   useradd -m test && \
+  #                   echo \"test ALL=(ALL) NOPASSWD: ALL\" >> /etc/sudoers && \
+  #                   su test -c \"git clone https://aur.archlinux.org/cnquery && cd cnquery && makepkg\" && \
+  #                   cd cnquery && pacman -U --noconfirm cnquery-*.zst && cd /tmp && \
+  #                   cnquery version && \
+  #                   su test -c \"git clone https://aur.archlinux.org/mql && cd mql && makepkg\" && \
+  #                   cd mql && pacman -U --noconfirm mql-*.zst && \
+  #                   mql version | grep -q ${{ steps.version.outputs.version }} && \
+  #                   ! pacman -Q cnquery"

--- a/.github/workflows/test-released-install-ps1.yaml
+++ b/.github/workflows/test-released-install-ps1.yaml
@@ -242,12 +242,13 @@ jobs:
         shell: pwsh
         run: |
           ./test/powershell/verify-cnspec-version.ps1 -ExpectedVersion "${{ steps.version.outputs.version }}" -BinaryBaseName "mql"
-      - name: Verify cnquery.exe points to cnspec (backward compat)
-        run: |
-          $version=& 'C:\Program Files\Mondoo\cnquery.exe' version
-          Write-Output "cnquery.exe version: $version"
-          $match=$version -like "*${{ steps.version.outputs.version }}*"
-          if (-not $match) {
-            Write-Error "cnquery.exe version mismatch"
-            exit 1
-          }
+      # TODO: re-enable once cnquery.exe is updated by the mql upgrade
+      # - name: Verify cnquery.exe points to cnspec (backward compat)
+      #   run: |
+      #     $version=& 'C:\Program Files\Mondoo\cnquery.exe' version
+      #     Write-Output "cnquery.exe version: $version"
+      #     $match=$version -like "*${{ steps.version.outputs.version }}*"
+      #     if (-not $match) {
+      #       Write-Error "cnquery.exe version mismatch"
+      #       exit 1
+      #     }

--- a/.github/workflows/test-released-install-sh.yaml
+++ b/.github/workflows/test-released-install-sh.yaml
@@ -217,78 +217,80 @@ jobs:
             if dpkg -l 2>/dev/null | awk '/^ii/{print \$2}' | grep -qx cnquery; then echo 'ERROR: cnquery should have been removed but is still installed'; exit 1; fi && \
             echo '==> SUCCESS: cnquery was properly replaced by mql'"
 
-  upgrade-from-cnquery-yum:
-    runs-on: ubuntu-latest
-    needs: wait-for-pkg
-    strategy:
-      fail-fast: false
-      matrix:
-        distro:
-          [
-            "quay.io/centos/centos:stream9",
-            "rockylinux:8",
-            "rockylinux:9",
-            "oraclelinux:8",
-            "oraclelinux:9",
-          ]
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: Version
-        id: version
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      - name: Upgrade cnquery -> mql on ${{ matrix.distro }}
-        run: |
-          docker run --rm -v $(pwd):/work -w /work ${{ matrix.distro }} \
-          bash -c "set -e && \
-            echo '==> Installing cnquery...' && \
-            curl -sSL https://install.mondoo.com/sh/cnquery | bash - && \
-            echo '==> Verifying cnquery is installed...' && \
-            rpm -q cnquery && \
-            echo '==> Installing mql (should replace cnquery)...' && \
-            curl -sSL https://install.mondoo.com/sh/mql | bash - && \
-            echo '==> Verifying mql version...' && \
-            mql version | grep -q ${{ steps.version.outputs.version }} && \
-            echo '==> Verifying cnquery was removed...' && \
-            if rpm -q cnquery >/dev/null 2>&1; then echo 'ERROR: cnquery should have been removed but is still installed'; exit 1; fi && \
-            echo '==> SUCCESS: cnquery was properly replaced by mql'"
+  # TODO: re-enable once the cnquery -> mql upgrade path works on yum-based distros
+  # upgrade-from-cnquery-yum:
+  #   runs-on: ubuntu-latest
+  #   needs: wait-for-pkg
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       distro:
+  #         [
+  #           "quay.io/centos/centos:stream9",
+  #           "rockylinux:8",
+  #           "rockylinux:9",
+  #           "oraclelinux:8",
+  #           "oraclelinux:9",
+  #         ]
+  #   steps:
+  #     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+  #     - name: Version
+  #       id: version
+  #       env:
+  #         INPUT_VERSION: ${{ inputs.version }}
+  #       run: |
+  #         VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
+  #         echo "version=${VERSION}" >> $GITHUB_OUTPUT
+  #     - name: Upgrade cnquery -> mql on ${{ matrix.distro }}
+  #       run: |
+  #         docker run --rm -v $(pwd):/work -w /work ${{ matrix.distro }} \
+  #         bash -c "set -e && \
+  #           echo '==> Installing cnquery...' && \
+  #           curl -sSL https://install.mondoo.com/sh/cnquery | bash - && \
+  #           echo '==> Verifying cnquery is installed...' && \
+  #           rpm -q cnquery && \
+  #           echo '==> Installing mql (should replace cnquery)...' && \
+  #           curl -sSL https://install.mondoo.com/sh/mql | bash - && \
+  #           echo '==> Verifying mql version...' && \
+  #           mql version | grep -q ${{ steps.version.outputs.version }} && \
+  #           echo '==> Verifying cnquery was removed...' && \
+  #           if rpm -q cnquery >/dev/null 2>&1; then echo 'ERROR: cnquery should have been removed but is still installed'; exit 1; fi && \
+  #           echo '==> SUCCESS: cnquery was properly replaced by mql'"
 
-  upgrade-from-cnquery-zypper:
-    runs-on: ubuntu-latest
-    needs: wait-for-pkg
-    strategy:
-      fail-fast: false
-      matrix:
-        distro:
-          [
-            "registry.suse.com/suse/sle15:15.6",
-          ]
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: Version
-        id: version
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      - name: Upgrade cnquery -> mql on ${{ matrix.distro }}
-        run: |
-          docker run --rm -v $(pwd):/work -w /work ${{ matrix.distro }} \
-          bash -c "set -e && \
-            echo '==> Installing curl...' && \
-            zypper -n install curl && \
-            echo '==> Installing cnquery...' && \
-            curl -sSL https://install.mondoo.com/sh/cnquery | bash - && \
-            echo '==> Verifying cnquery is installed...' && \
-            rpm -q cnquery && \
-            echo '==> Installing mql (should replace cnquery)...' && \
-            curl -sSL https://install.mondoo.com/sh/mql | bash - && \
-            echo '==> Verifying mql version...' && \
-            mql version | grep -q ${{ steps.version.outputs.version }} && \
-            echo '==> Verifying cnquery was removed...' && \
-            if rpm -q cnquery >/dev/null 2>&1; then echo 'ERROR: cnquery should have been removed but is still installed'; exit 1; fi && \
-            echo '==> SUCCESS: cnquery was properly replaced by mql'"
+  # TODO: re-enable once the cnquery -> mql upgrade path works on zypper-based distros
+  # upgrade-from-cnquery-zypper:
+  #   runs-on: ubuntu-latest
+  #   needs: wait-for-pkg
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       distro:
+  #         [
+  #           "registry.suse.com/suse/sle15:15.6",
+  #         ]
+  #   steps:
+  #     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+  #     - name: Version
+  #       id: version
+  #       env:
+  #         INPUT_VERSION: ${{ inputs.version }}
+  #       run: |
+  #         VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
+  #         echo "version=${VERSION}" >> $GITHUB_OUTPUT
+  #     - name: Upgrade cnquery -> mql on ${{ matrix.distro }}
+  #       run: |
+  #         docker run --rm -v $(pwd):/work -w /work ${{ matrix.distro }} \
+  #         bash -c "set -e && \
+  #           echo '==> Installing curl...' && \
+  #           zypper -n install curl && \
+  #           echo '==> Installing cnquery...' && \
+  #           curl -sSL https://install.mondoo.com/sh/cnquery | bash - && \
+  #           echo '==> Verifying cnquery is installed...' && \
+  #           rpm -q cnquery && \
+  #           echo '==> Installing mql (should replace cnquery)...' && \
+  #           curl -sSL https://install.mondoo.com/sh/mql | bash - && \
+  #           echo '==> Verifying mql version...' && \
+  #           mql version | grep -q ${{ steps.version.outputs.version }} && \
+  #           echo '==> Verifying cnquery was removed...' && \
+  #           if rpm -q cnquery >/dev/null 2>&1; then echo 'ERROR: cnquery should have been removed but is still installed'; exit 1; fi && \
+  #           echo '==> SUCCESS: cnquery was properly replaced by mql'"


### PR DESCRIPTION
## Summary
- Comments out the `arch-upgrade-cnquery-to-mql`, `upgrade-from-cnquery-yum`, and `upgrade-from-cnquery-zypper` jobs and the ps1 `Verify cnquery.exe points to cnspec` step that are consistently failing in the release test workflow (see run [25725514159](https://github.com/mondoohq/installer/actions/runs/25725514159/attempts/1)).
- The new mql package does not auto-remove the old cnquery package on rpm/pacman, and on Windows cnquery.exe is not refreshed by the mql install — these tests will keep failing until that upgrade path is fixed.
- The apt upgrade job passes and stays active.

## Test plan
- [ ] Trigger a release test run and confirm the workflow no longer fails on the upgrade jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)