### PR TITLE
Harden workflow input handling

### DIFF
--- a/.github/workflows/clear-minstaller-cache.yaml
+++ b/.github/workflows/clear-minstaller-cache.yaml
@@ -36,27 +36,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clear minstaller cache with retry
+        env:
+          CACHE_MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+          CACHE_RETRY_DELAY: ${{ inputs.retry_delay }}
+          MINSTALLER_API_KEY: ${{ secrets.MINSTALLER_API_KEY }}
         run: |
           echo "Clearing minstaller's cache..."
           cache_cleared=false
-          cache_max_attempts=${{ inputs.max_attempts }}
+          cache_max_attempts="${CACHE_MAX_ATTEMPTS}"
+          cache_retry_delay="${CACHE_RETRY_DELAY}"
           cache_attempt=1
-          
-          while [ $cache_attempt -le $cache_max_attempts ] && [ "$cache_cleared" = false ]; do
+
+          if [[ ! "$cache_max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Invalid max_attempts: $cache_max_attempts"
+            exit 1
+          fi
+          if [[ ! "$cache_retry_delay" =~ ^[0-9]+$ ]]; then
+            echo "Invalid retry_delay: $cache_retry_delay"
+            exit 1
+          fi
+
+          while [ "$cache_attempt" -le "$cache_max_attempts" ] && [ "$cache_cleared" = false ]; do
             echo "Cache clear attempt $cache_attempt/$cache_max_attempts..."
-            
+
             cache_response=$(curl -s -w "HTTP_CODE:%{http_code}" \
               -X POST https://install.mondoo.com/_/cache/clear-all \
-              -H "X-API-Key: ${{ secrets.MINSTALLER_API_KEY }}" 2>/dev/null || true)
+              -H "X-API-Key: ${MINSTALLER_API_KEY}" 2>/dev/null || true)
 
             if echo "$cache_response" | grep -q "HTTP_CODE:200"; then
               echo "✅ Cache cleared successfully on attempt $cache_attempt"
               cache_cleared=true
             else
               echo "⚠️ Cache clear attempt $cache_attempt failed..."
-              if [ $cache_attempt -lt $cache_max_attempts ]; then
-                echo "Waiting ${{ inputs.retry_delay }} seconds before retry..."
-                sleep ${{ inputs.retry_delay }}
+              if [ "$cache_attempt" -lt "$cache_max_attempts" ]; then
+                echo "Waiting $cache_retry_delay seconds before retry..."
+                sleep "$cache_retry_delay"
               fi
             fi
 

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -22,8 +22,12 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          echo "VERSION=${INPUT_VERSION}" >> $GITHUB_ENV
-          echo "version=${INPUT_VERSION}" >> $GITHUB_OUTPUT
+          if [[ ! "$INPUT_VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'VERSION=%s\n' "$INPUT_VERSION" >> "$GITHUB_ENV"
+          printf 'version=%s\n' "$INPUT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Clone repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/parse_inputs.yml
+++ b/.github/workflows/parse_inputs.yml
@@ -61,8 +61,8 @@ jobs:
           V="${VERSION##v}"
           echo "Version: $V"
           # strip trailing pre-release version e.g. 1.0.0-beta
-          trimmed_version="${V%%[-+]*}"
-          if [[ ! "$V" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+          trimmed_version="${V%%-*}"
+          if [[ ! "$V" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "Invalid version: $VERSION"
             exit 1
           fi

--- a/.github/workflows/parse_inputs.yml
+++ b/.github/workflows/parse_inputs.yml
@@ -60,14 +60,33 @@ jobs:
           # strip leading 'v', e.g. v1.0.0
           V="${VERSION##v}"
           echo "Version: $V"
-          echo "version=${V}" >> "$GITHUB_OUTPUT"
           # strip trailing pre-release version e.g. 1.0.0-beta
-          echo "trimmed_version=${V%%-*}" >> "$GITHUB_OUTPUT"
-          if [[ ! ${V%%-*} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          trimmed_version="${V%%[-+]*}"
+          if [[ ! "$V" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
             echo "Invalid version: $VERSION"
             exit 1
           fi
+          if [[ ! "$trimmed_version" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "Invalid trimmed version: $trimmed_version"
+            exit 1
+          fi
+          if [[ ! "$NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "Invalid package name: $NAME"
+            exit 1
+          fi
+          if [[ ! "$BUCKET" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "Invalid bucket name: $BUCKET"
+            exit 1
+          fi
+          if [[ "$SKIP_PUBLISH" != "true" && "$SKIP_PUBLISH" != "false" ]]; then
+            echo "Invalid skip-publish value: $SKIP_PUBLISH"
+            exit 1
+          fi
 
-          echo "name=$NAME" >> "$GITHUB_OUTPUT"
-          echo "skip-publish=$SKIP_PUBLISH" >> "$GITHUB_OUTPUT"
-          echo "bucket=$BUCKET" >> "$GITHUB_OUTPUT"
+          {
+            printf 'version=%s\n' "$V"
+            printf 'trimmed_version=%s\n' "$trimmed_version"
+            printf 'name=%s\n' "$NAME"
+            printf 'skip-publish=%s\n' "$SKIP_PUBLISH"
+            printf 'bucket=%s\n' "$BUCKET"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pkg_chocolatey.yaml
+++ b/.github/workflows/pkg_chocolatey.yaml
@@ -47,25 +47,33 @@ jobs:
       - name: Validate inputs
         env:
           VERSION: ${{ inputs.version }}
+          PACKAGE: ${{ matrix.package }}
         run: |
           if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
             echo "Invalid version: $VERSION"
+            exit 1
+          fi
+          if [[ "$PACKAGE" != "mql" && "$PACKAGE" != "cnspec" && "$PACKAGE" != "cnquery" ]]; then
+            echo "Invalid package: $PACKAGE"
             exit 1
           fi
 
       - name: Generate and Validate Package
         env:
           VERSION: ${{ inputs.version }}
-        run: make -C packages/chocolatey generate validate VERSION="$VERSION" PACKAGES=${{ matrix.package }}
+          PACKAGE: ${{ matrix.package }}
+        run: make -C packages/chocolatey generate validate VERSION="$VERSION" PACKAGES="$PACKAGE"
 
       - name: Pack Package
         env:
           VERSION: ${{ inputs.version }}
-        run: make -C packages/chocolatey pack VERSION="$VERSION" PACKAGES=${{ matrix.package }}
+          PACKAGE: ${{ matrix.package }}
+        run: make -C packages/chocolatey pack VERSION="$VERSION" PACKAGES="$PACKAGE"
 
       - name: Publish Package
         if: ${{ ! inputs.skip-publish }}
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
           VERSION: ${{ inputs.version }}
-        run: make -C packages/chocolatey publish VERSION="$VERSION" PACKAGES=${{ matrix.package }}
+          PACKAGE: ${{ matrix.package }}
+        run: make -C packages/chocolatey publish VERSION="$VERSION" PACKAGES="$PACKAGE"

--- a/.github/workflows/pkg_chocolatey.yaml
+++ b/.github/workflows/pkg_chocolatey.yaml
@@ -44,15 +44,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
+      - name: Validate inputs
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $VERSION"
+            exit 1
+          fi
+
       - name: Generate and Validate Package
-        run: make -C packages/chocolatey generate validate VERSION=${{ inputs.version }} PACKAGES=${{ matrix.package }}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: make -C packages/chocolatey generate validate VERSION="$VERSION" PACKAGES=${{ matrix.package }}
 
       - name: Pack Package
-        run: make -C packages/chocolatey pack VERSION=${{ inputs.version }} PACKAGES=${{ matrix.package }}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: make -C packages/chocolatey pack VERSION="$VERSION" PACKAGES=${{ matrix.package }}
 
       - name: Publish Package
         if: ${{ ! inputs.skip-publish }}
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
-        run: make -C packages/chocolatey publish VERSION=${{ inputs.version }} PACKAGES=${{ matrix.package }}
-
+          VERSION: ${{ inputs.version }}
+        run: make -C packages/chocolatey publish VERSION="$VERSION" PACKAGES=${{ matrix.package }}

--- a/.github/workflows/pkg_macos.yaml
+++ b/.github/workflows/pkg_macos.yaml
@@ -82,37 +82,61 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Ensure version of mql and cnspec are available
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          curl -sL --head --fail https://github.com/mondoohq/mql/releases/download/v${{ inputs.version }}/mql_${{ inputs.version }}_darwin_amd64.tar.gz
-          curl -sL --head --fail https://github.com/mondoohq/cnspec/releases/download/v${{ inputs.version }}/cnspec_${{ inputs.version }}_darwin_amd64.tar.gz
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $VERSION"
+            exit 1
+          fi
+          curl -sL --head --fail "https://github.com/mondoohq/mql/releases/download/v${VERSION}/mql_${VERSION}_darwin_amd64.tar.gz"
+          curl -sL --head --fail "https://github.com/mondoohq/cnspec/releases/download/v${VERSION}/cnspec_${VERSION}_darwin_amd64.tar.gz"
       - name: Setup local keychain for signing certificates
+        env:
+          APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+          APPLE_KEYS_PRODUCTSIGN_P12: ${{ secrets.APPLE_KEYS_PRODUCTSIGN_P12 }}
+          APPLE_KEYS_CODESIGN_P12: ${{ secrets.APPLE_KEYS_CODESIGN_P12 }}
+          APPLE_KEYS_PASSWORD: ${{ secrets.APPLE_KEYS_PASSWORD }}
         run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
           # Setup Keychain:
-          security create-keychain -p ${{ secrets.APPLE_KEYCHAIN_PASSWORD }} $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p ${{ secrets.APPLE_KEYCHAIN_PASSWORD }} $KEYCHAIN_PATH
+          security create-keychain -p "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           # Import Certificates:
-          echo "${{ secrets.APPLE_KEYS_PRODUCTSIGN_P12 }}" | base64 --decode > $RUNNER_TEMP/AppleKeysProductSign.p12
-          echo "${{ secrets.APPLE_KEYS_CODESIGN_P12 }}"  | base64 --decode > $RUNNER_TEMP/AppleKeysCodeSign.p12
-          security import $RUNNER_TEMP/AppleKeysProductSign.p12 -P ${{ secrets.APPLE_KEYS_PASSWORD }} -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security import $RUNNER_TEMP/AppleKeysCodeSign.p12 -P ${{ secrets.APPLE_KEYS_PASSWORD }} -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
+          printf '%s' "$APPLE_KEYS_PRODUCTSIGN_P12" | base64 --decode > "$RUNNER_TEMP/AppleKeysProductSign.p12"
+          printf '%s' "$APPLE_KEYS_CODESIGN_P12" | base64 --decode > "$RUNNER_TEMP/AppleKeysCodeSign.p12"
+          security import "$RUNNER_TEMP/AppleKeysProductSign.p12" -P "$APPLE_KEYS_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security import "$RUNNER_TEMP/AppleKeysCodeSign.p12" -P "$APPLE_KEYS_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
       ########## Build Package. ##########
       - name: Run Mac Packager
         env:
           APPLE_KEYS_CODESIGN_ID: ${{ secrets.APPLE_KEYS_CODESIGN_ID }}
           APPLE_KEYS_PRODUCTSIGN_ID: ${{ secrets.APPLE_KEYS_PRODUCTSIGN_ID }}
           PKGNAME: ${{ inputs.name }}
+          VERSION: ${{ inputs.version }}
         run: |
-          ${GITHUB_WORKSPACE}/packages/macos/build-pkg.sh ${{ inputs.version }}
+          if [[ ! "$PKGNAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "Invalid package name: $PKGNAME"
+            exit 1
+          fi
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $VERSION"
+            exit 1
+          fi
+          "${GITHUB_WORKSPACE}/packages/macos/build-pkg.sh" "$VERSION"
       - name: Inspect Distribution
         if: ${{ always() }}
         run: ls -lhR
       ########## Sign Package. ##########
       - name: Package Sign Package (productsign)
+        env:
+          APPLE_KEYS_PRODUCTSIGN_ID: ${{ secrets.APPLE_KEYS_PRODUCTSIGN_ID }}
+          PKGNAME: ${{ inputs.name }}
+          VERSION: ${{ inputs.version }}
         run: |
-          productsign --sign "${{ secrets.APPLE_KEYS_PRODUCTSIGN_ID }}" dist/${{ inputs.name }}-macos-universal-${{ inputs.version }}.pkg dist/${{ inputs.name }}_${{ inputs.version }}_darwin_universal.pkg
+          productsign --sign "$APPLE_KEYS_PRODUCTSIGN_ID" "dist/${PKGNAME}-macos-universal-${VERSION}.pkg" "dist/${PKGNAME}_${VERSION}_darwin_universal.pkg"
       ########## Sign Package. ##########
       - name: Notarize Package
         uses: lando/notarize-action@b5c3ef16cf2fbcf2af26dc58c90255ec242abeed # v2.0.2
@@ -149,6 +173,9 @@ jobs:
           name: notarized-package
           path: dist
       - name: Get Version & Checksum
+        env:
+          PKGNAME: ${{ inputs.name }}
+          VERSION: ${{ inputs.version }}
         run: |
           cd dist
           # Ensure we only have a single file
@@ -157,7 +184,7 @@ jobs:
             echo "We have more than one file in the dist folder. This is not expected."
             exit 1
           fi
-          sha256sum ${{ inputs.name }}_${{ inputs.version }}_darwin_universal.pkg | tee -a checksums.macos.txt
+          sha256sum "${PKGNAME}_${VERSION}_darwin_universal.pkg" | tee -a checksums.macos.txt
       - name: Authenticate with Google Cloud
         uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # v3.0.0
         with:
@@ -165,12 +192,17 @@ jobs:
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db' # v3.0.1
       - name: Verify access to release bucket
+        env:
+          BUCKET: ${{ inputs.bucket }}
         run: |
-          gsutil ls gs://${{ inputs.bucket }}/mondoo
+          gsutil ls "gs://${BUCKET}/mondoo"
       - name: Upload static content to buckets
         env:
           SKIP: ${{ inputs.skip-publish && 'echo skipping...' || '' }}
+          BUCKET: ${{ inputs.bucket }}
+          PKGNAME: ${{ inputs.name }}
+          VERSION: ${{ inputs.version }}
         run: |
           cd dist
-          $SKIP gsutil cp checksums.macos.txt gs://${{ inputs.bucket }}/mondoo/${{ inputs.version }}/checksums.macos.txt
-          $SKIP gsutil cp ${{ inputs.name }}_${{ inputs.version }}_darwin_universal.pkg gs://${{ inputs.bucket }}/mondoo/${{ inputs.version }}/${{ inputs.name }}_${{ inputs.version }}_darwin_universal.pkg
+          $SKIP gsutil cp checksums.macos.txt "gs://${BUCKET}/mondoo/${VERSION}/checksums.macos.txt"
+          $SKIP gsutil cp "${PKGNAME}_${VERSION}_darwin_universal.pkg" "gs://${BUCKET}/mondoo/${VERSION}/${PKGNAME}_${VERSION}_darwin_universal.pkg"

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -265,6 +265,16 @@ jobs:
       - dist-prepare
     #  For Version: ${{ inputs.version }}
     steps:
+      - name: Validate arch
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          $arch = $env:ARCH
+          if (@("amd64", "arm64") -notcontains $arch) {
+            Write-Error "Invalid arch: $arch"
+            exit 1
+          }
+
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
@@ -280,11 +290,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           $mondooVersion = ${env:VERSION}
-          $arch = ${env:ARCH}
-          if (@("amd64", "arm64") -notcontains $arch) {
-            Write-Error "Invalid arch: $arch"
-            exit 1
-          }
+          $arch = $env:ARCH
           echo "Running build job for version ${mondooVersion}"
           Copy-Item ".\dist\$arch\mql.exe" .\packages\msi\msi\
           Copy-Item ".\dist\$arch\cnspec.exe" .\packages\msi\msi\
@@ -331,11 +337,7 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
         run: |
-          $arch = ${env:ARCH}
-          if (@("amd64", "arm64") -notcontains $arch) {
-            Write-Error "Invalid arch: $arch"
-            exit 1
-          }
+          $arch = $env:ARCH
           Copy-Item ".\packages\msi\mondoo_${arch}.msi" ".\dist\$arch"
           Remove-Item -Path ".\dist\$arch\mql.exe" -Force
           Remove-Item -Path ".\dist\$arch\cnspec.exe" -Force
@@ -359,6 +361,16 @@ jobs:
       - msi-build
     runs-on: windows-2025
     steps:
+      - name: Validate arch
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          $arch = $env:ARCH
+          if (@("amd64", "arm64") -notcontains $arch) {
+            Write-Error "Invalid arch: $arch"
+            exit 1
+          }
+
       - name: Download MSI Package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -370,11 +382,7 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
         run: |
-          $arch = ${env:ARCH}
-          if (@("amd64", "arm64") -notcontains $arch) {
-            Write-Error "Invalid arch: $arch"
-            exit 1
-          }
+          $arch = $env:ARCH
           $msiFileName = "mondoo_${arch}.msi"
           $msiFilePath = Join-Path -Path (Get-Location) -ChildPath "dist\$msiFileName"
 
@@ -428,11 +436,7 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
         run: |
-          $arch = ${env:ARCH}
-          if (@("amd64", "arm64") -notcontains $arch) {
-            Write-Error "Invalid arch: $arch"
-            exit 1
-          }
+          $arch = $env:ARCH
           $TEMP_PATH = $env:TEMP
           cd dist
           $msiexec = Start-Process "msiexec" "/i mondoo_${arch}.msi /qn /l*! install.log" -NoNewWindow -PassThru

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -68,7 +68,14 @@ jobs:
         run: echo "$INPUTS_JSON"
 
       - name: Ensure version of mql and cnspec are available
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $VERSION"
+            exit 1
+          fi
+
           # Function to check URL with retry logic
           check_url_with_retry() {
             local url="$1"
@@ -95,12 +102,12 @@ jobs:
 
           # Check all required URLs
           urls=(
-            "https://github.com/mondoohq/mql/releases/download/v${{ inputs.version }}/mql_${{ inputs.version }}_windows_amd64.zip"
-            "https://github.com/mondoohq/cnspec/releases/download/v${{ inputs.version }}/cnspec_${{ inputs.version }}_windows_amd64.zip"
-            "https://github.com/mondoohq/mql/releases/download/v${{ inputs.version }}/mql_${{ inputs.version }}_windows_arm64.zip"
-            "https://github.com/mondoohq/cnspec/releases/download/v${{ inputs.version }}/cnspec_${{ inputs.version }}_windows_arm64.zip"
-            "https://github.com/mondoohq/mql/releases/download/v${{ inputs.version }}/mql_v${{ inputs.version }}_SHA256SUMS"
-            "https://github.com/mondoohq/cnspec/releases/download/v${{ inputs.version }}/cnspec_v${{ inputs.version }}_SHA256SUMS"
+            "https://github.com/mondoohq/mql/releases/download/v${VERSION}/mql_${VERSION}_windows_amd64.zip"
+            "https://github.com/mondoohq/cnspec/releases/download/v${VERSION}/cnspec_${VERSION}_windows_amd64.zip"
+            "https://github.com/mondoohq/mql/releases/download/v${VERSION}/mql_${VERSION}_windows_arm64.zip"
+            "https://github.com/mondoohq/cnspec/releases/download/v${VERSION}/cnspec_${VERSION}_windows_arm64.zip"
+            "https://github.com/mondoohq/mql/releases/download/v${VERSION}/mql_v${VERSION}_SHA256SUMS"
+            "https://github.com/mondoohq/cnspec/releases/download/v${VERSION}/cnspec_v${VERSION}_SHA256SUMS"
           )
 
           failed=0
@@ -115,7 +122,7 @@ jobs:
             exit 1
           fi
 
-          echo "✓ All required binaries are available for version ${{ inputs.version }}"
+          echo "✓ All required binaries are available for version $VERSION"
 
   dist-prepare:
     name: Prepare Distribution for Packaging
@@ -399,10 +406,12 @@ jobs:
           $gci.Kill()
           gci
       - name: Verify the correct mql version is installed
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
         run: |
           $version=& 'C:\Program Files\Mondoo\mql.exe' version
-          Write-Output "comparing $version -like '*${{ inputs.version }}*'"
-          $match=$version -like "*${{ inputs.version }}*"
+          Write-Output "comparing $version -like '*$env:EXPECTED_VERSION*'"
+          $match=$version -like "*$env:EXPECTED_VERSION*"
           if (-not $match) {
             exit 1
           }
@@ -410,10 +419,12 @@ jobs:
         run: |
           & 'C:\Program Files\Mondoo\mql.exe' run -c "os.base.packages.where(name == 'Mondoo') { name }"
       - name: Verify the correct cnspec version is installed
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
         run: |
           $version=& 'C:\Program Files\Mondoo\cnspec.exe' version
-          Write-Output "comparing $version -like '*${{ inputs.version }}*'"
-          $match=$version -like "*${{ inputs.version }}*"
+          Write-Output "comparing $version -like '*$env:EXPECTED_VERSION*'"
+          $match=$version -like "*$env:EXPECTED_VERSION*"
           if (-not $match) {
             exit 1
           }
@@ -421,8 +432,10 @@ jobs:
         run: |
           & 'C:\Program Files\Mondoo\cnspec.exe' run -c "os.base.packages.where(name == 'Mondoo') { name }"
       - name: Login to edge with cnspec
+        env:
+          REGISTRATION_TOKEN: ${{ secrets.INSTALL_TEST_MONDOO_REGISTRATION_TOKEN }}
         run: |
-          & 'C:\Program Files\Mondoo\cnspec.exe' login -t "${{ secrets.INSTALL_TEST_MONDOO_REGISTRATION_TOKEN }}" --config C:\ProgramData\Mondoo\mondoo.yml
+          & 'C:\Program Files\Mondoo\cnspec.exe' login -t "$env:REGISTRATION_TOKEN" --config C:\ProgramData\Mondoo\mondoo.yml
       - name: Run a basic cnspec sanity check
         run: |
           & 'C:\Program Files\Mondoo\cnspec.exe' policy download mondoo-windows-installer -f mondoo-windows-installer.mql.yaml
@@ -431,10 +444,12 @@ jobs:
         run: |
           & 'C:\Program Files\Mondoo\cnspec.exe' logout --config C:\ProgramData\Mondoo\mondoo.yml --force
       - name: Verify cnquery.exe points to cnspec (backward compat)
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
         run: |
           $version=& 'C:\Program Files\Mondoo\cnquery.exe' version
-          Write-Output "comparing $version -like '*${{ inputs.version }}*'"
-          $match=$version -like "*${{ inputs.version }}*"
+          Write-Output "comparing $version -like '*$env:EXPECTED_VERSION*'"
+          $match=$version -like "*$env:EXPECTED_VERSION*"
           if (-not $match) {
             exit 1
           }
@@ -470,18 +485,20 @@ jobs:
       - name: Verify access to release bucket
         env:
           VERSION: ${{ inputs.version }}
+          BUCKET: ${{ inputs.bucket }}
         run: |
-          gsutil ls gs://${{ inputs.bucket }}/mondoo
+          gsutil ls "gs://${BUCKET}/mondoo"
       - name: Upload static content to buckets
         env:
           VERSION: ${{ inputs.version }}
+          BUCKET: ${{ inputs.bucket }}
           SKIP: ${{ inputs.skip-publish && 'echo skipping...' || '' }}
         run: |
           cd dist
           mv mondoo_${{ matrix.arch }}.msi mondoo_${VERSION}_windows_${{ matrix.arch }}.msi
           sha256sum mondoo_${VERSION}_windows_${{ matrix.arch }}.msi >> checksums.windows_${{ matrix.arch }}.txt
-          $SKIP gsutil cp checksums.windows_${{ matrix.arch }}.txt gs://${{ inputs.bucket }}/mondoo/${VERSION}/checksums.windows_${{ matrix.arch }}.txt
-          $SKIP gsutil cp mondoo_${VERSION}_windows_${{ matrix.arch }}.msi gs://${{ inputs.bucket }}/mondoo/${VERSION}/mondoo_${VERSION}_windows_${{ matrix.arch }}.msi
+          $SKIP gsutil cp checksums.windows_${{ matrix.arch }}.txt "gs://${BUCKET}/mondoo/${VERSION}/checksums.windows_${{ matrix.arch }}.txt"
+          $SKIP gsutil cp mondoo_${VERSION}_windows_${{ matrix.arch }}.msi "gs://${BUCKET}/mondoo/${VERSION}/mondoo_${VERSION}_windows_${{ matrix.arch }}.msi"
       - name: Cleanup
         run: |
           rm -f "${{ steps.gauth.outputs.credentials_file_path }}"

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -268,6 +268,7 @@ jobs:
       - name: Validate arch
         env:
           ARCH: ${{ matrix.arch }}
+        shell: pwsh
         run: |
           $arch = $env:ARCH
           if (@("amd64", "arm64") -notcontains $arch) {
@@ -364,6 +365,7 @@ jobs:
       - name: Validate arch
         env:
           ARCH: ${{ matrix.arch }}
+        shell: pwsh
         run: |
           $arch = $env:ARCH
           if (@("amd64", "arm64") -notcontains $arch) {

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -139,10 +139,16 @@ jobs:
       - name: Download, Verify and Extract the Binaries
         env:
           VERSION: ${{ inputs.version }}
+          ARCH: ${{ matrix.arch }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if [[ "$ARCH" != "amd64" && "$ARCH" != "arm64" ]]; then
+            echo "Invalid arch: $ARCH"
+            exit 1
+          fi
+
           # Create directory and enter it
-          mkdir -p dist/${{ matrix.arch }} && cd dist/${{ matrix.arch }}
+          mkdir -p "dist/${ARCH}" && cd "dist/${ARCH}"
 
           # Function to download with retry logic
           download_with_retry() {
@@ -181,17 +187,18 @@ jobs:
           fi
 
           # Download cnspec
-          if ! download_with_retry "https://github.com/mondoohq/cnspec/releases/download/v${VERSION}/cnspec_${VERSION}_windows_${{ matrix.arch }}.zip" "cnspec_${VERSION}_windows_${{ matrix.arch }}.zip"; then
+          cnspec_zip="cnspec_${VERSION}_windows_${ARCH}.zip"
+          if ! download_with_retry "https://github.com/mondoohq/cnspec/releases/download/v${VERSION}/${cnspec_zip}" "$cnspec_zip"; then
             exit 1
           fi
 
           # Validate cnspec checksum
-          expected_checksum=$(grep "cnspec_${VERSION}_windows_${{ matrix.arch }}.zip" cnspec_v${VERSION}_SHA256SUMS | awk '{print $1}')
+          expected_checksum=$(grep "$cnspec_zip" "cnspec_v${VERSION}_SHA256SUMS" | awk '{print $1}')
           if [ -z "$expected_checksum" ]; then
-            echo "ERROR: Could not find expected checksum for cnspec_${VERSION}_windows_${{ matrix.arch }}.zip"
+            echo "ERROR: Could not find expected checksum for $cnspec_zip"
             exit 1
           fi
-          actual_checksum=$(sha256sum "cnspec_${VERSION}_windows_${{ matrix.arch }}.zip" | awk '{print $1}')
+          actual_checksum=$(sha256sum "$cnspec_zip" | awk '{print $1}')
           if [ "$actual_checksum" != "$expected_checksum" ]; then
             echo "ERROR: Checksum mismatch for cnspec binary"
             echo "Expected: $expected_checksum"
@@ -201,24 +208,25 @@ jobs:
           echo "✓ cnspec checksum validated successfully"
 
           # Extract and cleanup cnspec
-          if ! unzip cnspec_${VERSION}_windows_${{ matrix.arch }}.zip; then
+          if ! unzip "$cnspec_zip"; then
             echo "ERROR: Failed to extract cnspec binary"
             exit 1
           fi
-          rm cnspec_${VERSION}_windows_${{ matrix.arch }}.zip cnspec_v${VERSION}_SHA256SUMS
+          rm "$cnspec_zip" "cnspec_v${VERSION}_SHA256SUMS"
 
           # Download mql
-          if ! download_with_retry "https://github.com/mondoohq/mql/releases/download/v${VERSION}/mql_${VERSION}_windows_${{ matrix.arch }}.zip" "mql_${VERSION}_windows_${{ matrix.arch }}.zip"; then
+          mql_zip="mql_${VERSION}_windows_${ARCH}.zip"
+          if ! download_with_retry "https://github.com/mondoohq/mql/releases/download/v${VERSION}/${mql_zip}" "$mql_zip"; then
             exit 1
           fi
 
           # Validate mql checksum
-          expected_checksum=$(grep "mql_${VERSION}_windows_${{ matrix.arch }}.zip" mql_v${VERSION}_SHA256SUMS | awk '{print $1}')
+          expected_checksum=$(grep "$mql_zip" "mql_v${VERSION}_SHA256SUMS" | awk '{print $1}')
           if [ -z "$expected_checksum" ]; then
-            echo "ERROR: Could not find expected checksum for mql_${VERSION}_windows_${{ matrix.arch }}.zip"
+            echo "ERROR: Could not find expected checksum for $mql_zip"
             exit 1
           fi
-          actual_checksum=$(sha256sum "mql_${VERSION}_windows_${{ matrix.arch }}.zip" | awk '{print $1}')
+          actual_checksum=$(sha256sum "$mql_zip" | awk '{print $1}')
           if [ "$actual_checksum" != "$expected_checksum" ]; then
             echo "ERROR: Checksum mismatch for mql binary"
             echo "Expected: $expected_checksum"
@@ -228,11 +236,11 @@ jobs:
           echo "✓ mql checksum validated successfully"
 
           # Extract and cleanup mql
-          if ! unzip mql_${VERSION}_windows_${{ matrix.arch }}.zip; then
+          if ! unzip "$mql_zip"; then
             echo "ERROR: Failed to extract mql binary"
             exit 1
           fi
-          rm mql_${VERSION}_windows_${{ matrix.arch }}.zip mql_v${VERSION}_SHA256SUMS
+          rm "$mql_zip" "mql_v${VERSION}_SHA256SUMS"
 
           echo "Successfully downloaded and extracted binaries:"
           ls -lh
@@ -269,18 +277,24 @@ jobs:
       - name: Build MSI
         env:
           VERSION: ${{ inputs.version }}
+          ARCH: ${{ matrix.arch }}
         run: |
           $mondooVersion = ${env:VERSION}
+          $arch = ${env:ARCH}
+          if (@("amd64", "arm64") -notcontains $arch) {
+            Write-Error "Invalid arch: $arch"
+            exit 1
+          }
           echo "Running build job for version ${mondooVersion}"
-          Copy-Item .\dist\${{ matrix.arch }}\mql.exe .\packages\msi\msi\
-          Copy-Item .\dist\${{ matrix.arch }}\cnspec.exe .\packages\msi\msi\
-          Copy-Item .\dist\${{ matrix.arch }}\cnspec.exe .\packages\msi\msi\cnquery.exe
-          Copy-Item .\dist\${{ matrix.arch }}\mql.exe .\packages\msi\appx\
-          Copy-Item .\dist\${{ matrix.arch }}\cnspec.exe .\packages\msi\appx\
+          Copy-Item ".\dist\$arch\mql.exe" .\packages\msi\msi\
+          Copy-Item ".\dist\$arch\cnspec.exe" .\packages\msi\msi\
+          Copy-Item ".\dist\$arch\cnspec.exe" .\packages\msi\msi\cnquery.exe
+          Copy-Item ".\dist\$arch\mql.exe" .\packages\msi\appx\
+          Copy-Item ".\dist\$arch\cnspec.exe" .\packages\msi\appx\
           # build msi package
           echo " - Packaging MSI..."
           Set-Location -Path '.\packages\msi\'
-          ./package.ps1 -version $mondooVersion -arch ${{ matrix.arch }}
+          ./package.ps1 -version $mondooVersion -arch $arch
 
       - name: Azure login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
@@ -314,10 +328,17 @@ jobs:
           cache-dependencies: true
 
       - name: Cleanup dist before upload
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
-          Copy-Item '.\packages\msi\mondoo_${{ matrix.arch }}.msi' '.\dist\${{ matrix.arch }}'
-          Remove-Item -Path .\dist\${{ matrix.arch }}\mql.exe -Force
-          Remove-Item -Path .\dist\${{ matrix.arch }}\cnspec.exe -Force
+          $arch = ${env:ARCH}
+          if (@("amd64", "arm64") -notcontains $arch) {
+            Write-Error "Invalid arch: $arch"
+            exit 1
+          }
+          Copy-Item ".\packages\msi\mondoo_${arch}.msi" ".\dist\$arch"
+          Remove-Item -Path ".\dist\$arch\mql.exe" -Force
+          Remove-Item -Path ".\dist\$arch\cnspec.exe" -Force
 
       - name: Upload Distribution
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -346,8 +367,15 @@ jobs:
       - name: Verify Signed MSI Status
         if: ${{ inputs.use-test-cert == false }}
         shell: powershell
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
-          $msiFileName = "mondoo_${{ matrix.arch }}.msi"
+          $arch = ${env:ARCH}
+          if (@("amd64", "arm64") -notcontains $arch) {
+            Write-Error "Invalid arch: $arch"
+            exit 1
+          }
+          $msiFileName = "mondoo_${arch}.msi"
           $msiFilePath = Join-Path -Path (Get-Location) -ChildPath "dist\$msiFileName"
 
           Write-Host "Attempting to verify digital signature for MSI: $msiFilePath"
@@ -397,10 +425,17 @@ jobs:
               exit 1 # Fail the step
           }
       - name: Install artifact
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
+          $arch = ${env:ARCH}
+          if (@("amd64", "arm64") -notcontains $arch) {
+            Write-Error "Invalid arch: $arch"
+            exit 1
+          }
           $TEMP_PATH = $env:TEMP
           cd dist
-          $msiexec = Start-Process "msiexec" "/i mondoo_${{ matrix.arch }}.msi /qn /l*! install.log" -NoNewWindow -PassThru
+          $msiexec = Start-Process "msiexec" "/i mondoo_${arch}.msi /qn /l*! install.log" -NoNewWindow -PassThru
           $gci = Start-Process "powershell" "Get-Content -Path install.log -Wait" -NoNewWindow -PassThru
           $msiexec.WaitForExit() 
           $gci.Kill()
@@ -492,13 +527,18 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           BUCKET: ${{ inputs.bucket }}
+          ARCH: ${{ matrix.arch }}
           SKIP: ${{ inputs.skip-publish && 'echo skipping...' || '' }}
         run: |
           cd dist
-          mv mondoo_${{ matrix.arch }}.msi mondoo_${VERSION}_windows_${{ matrix.arch }}.msi
-          sha256sum mondoo_${VERSION}_windows_${{ matrix.arch }}.msi >> checksums.windows_${{ matrix.arch }}.txt
-          $SKIP gsutil cp checksums.windows_${{ matrix.arch }}.txt "gs://${BUCKET}/mondoo/${VERSION}/checksums.windows_${{ matrix.arch }}.txt"
-          $SKIP gsutil cp mondoo_${VERSION}_windows_${{ matrix.arch }}.msi "gs://${BUCKET}/mondoo/${VERSION}/mondoo_${VERSION}_windows_${{ matrix.arch }}.msi"
+          if [[ "$ARCH" != "amd64" && "$ARCH" != "arm64" ]]; then
+            echo "Invalid arch: $ARCH"
+            exit 1
+          fi
+          mv "mondoo_${ARCH}.msi" "mondoo_${VERSION}_windows_${ARCH}.msi"
+          sha256sum "mondoo_${VERSION}_windows_${ARCH}.msi" >> "checksums.windows_${ARCH}.txt"
+          $SKIP gsutil cp "checksums.windows_${ARCH}.txt" "gs://${BUCKET}/mondoo/${VERSION}/checksums.windows_${ARCH}.txt"
+          $SKIP gsutil cp "mondoo_${VERSION}_windows_${ARCH}.msi" "gs://${BUCKET}/mondoo/${VERSION}/mondoo_${VERSION}_windows_${ARCH}.msi"
       - name: Cleanup
         run: |
           rm -f "${{ steps.gauth.outputs.credentials_file_path }}"

--- a/.github/workflows/pkg_published_trigger_build_release.yaml
+++ b/.github/workflows/pkg_published_trigger_build_release.yaml
@@ -155,8 +155,12 @@ jobs:
           BUCKET: ${{ needs.parse-inputs.outputs.bucket }}
           REINDEX_PATH: ${{ inputs.reindex-path }}
         run: |
-          echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
-          echo "reindex-path=${REINDEX_PATH}" >> $GITHUB_OUTPUT
+          if [[ -n "$REINDEX_PATH" && ! "$REINDEX_PATH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "Invalid reindex-path: $REINDEX_PATH"
+            exit 1
+          fi
+          printf 'bucket=%s\n' "$BUCKET" >> "$GITHUB_OUTPUT"
+          printf 'reindex-path=%s\n' "$REINDEX_PATH" >> "$GITHUB_OUTPUT"
       - name: "Authenticate to Google Cloud"
         uses: "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093" # v3.0.0
         with:
@@ -182,19 +186,22 @@ jobs:
           TOKEN: ${{ steps.auth.outputs.id_token }}
           BUCKETNAME: ${{ needs.parse-inputs.outputs.bucket }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          VERSION: ${{ needs.parse-inputs.outputs.version }}
           SKIP: ${{ (needs.parse-inputs.outputs.skip-publish == 'true') && 'echo skipping...' || '' }}
         run: |
-          $SKIP ./releasr release cp  https://github.com/mondoohq/mql/releases/tag/v${{ needs.parse-inputs.outputs.version }} gs://${{ needs.parse-inputs.outputs.bucket }}
-          $SKIP ./releasr release cp  https://github.com/mondoohq/cnspec/releases/tag/v${{ needs.parse-inputs.outputs.version }} gs://${{ needs.parse-inputs.outputs.bucket }}
+          $SKIP ./releasr release cp "https://github.com/mondoohq/mql/releases/tag/v${VERSION}" "gs://${BUCKETNAME}"
+          $SKIP ./releasr release cp "https://github.com/mondoohq/cnspec/releases/tag/v${VERSION}" "gs://${BUCKETNAME}"
       - name: "Remove Artifacts.json & Index.html from path (Optional)"
         env:
+          BUCKETNAME: ${{ needs.parse-inputs.outputs.bucket }}
+          REINDEX_PATH: ${{ steps.inputs.outputs.reindex-path }}
           SKIP: ${{ (needs.parse-inputs.outputs.skip-publish == 'true') && 'echo skipping...' || '' }}
         run: |
-          if [ -n "${{ inputs.reindex-path }}" ]; then
-            echo "Removing artifacts.json & index.html from path ${{ inputs.reindex-path }}"
+          if [ -n "$REINDEX_PATH" ]; then
+            echo "Removing artifacts.json & index.html from path $REINDEX_PATH"
             # If the files don't exist this will fail, but that's ok
-            $SKIP gsutil rm gs://${{ needs.parse-inputs.outputs.bucket }}/${{ inputs.reindex-path }}/artifacts.json || true
-            $SKIP gsutil rm gs://${{ needs.parse-inputs.outputs.bucket }}/${{ inputs.reindex-path }}/index.html || true
+            $SKIP gsutil rm "gs://${BUCKETNAME}/${REINDEX_PATH}/artifacts.json" || true
+            $SKIP gsutil rm "gs://${BUCKETNAME}/${REINDEX_PATH}/index.html" || true
           fi
       - name: Regenerate Release Indexes
         env:
@@ -204,7 +211,7 @@ jobs:
           IDX_OPTS: ${{ inputs.reindex-full && '--force-recompute' || '' }}
           SKIP: ${{ (needs.parse-inputs.outputs.skip-publish == 'true') && 'echo skipping...' || '' }}
         run: |
-          $SKIP ./releasr idx gs://${{ needs.parse-inputs.outputs.bucket }} $IDX_OPTS
+          $SKIP ./releasr idx "gs://${BUCKETNAME}" $IDX_OPTS
       - name: Restart minstaller Cloud Run Service
         env:
           MINSTALLER: ${{ (needs.parse-inputs.outputs.skip-publish == 'true') && 'minstaller-dev' || 'minstaller' }}
@@ -215,8 +222,10 @@ jobs:
               run services replace "$MINSTALLER.yaml" --region us-central1
           rm "$MINSTALLER.yaml"
       - name: Invalidate Google Load Balancer caches (ETA~10 minutes)
+        env:
+          REINDEX_PATH: ${{ steps.inputs.outputs.reindex-path || '*' }}
         run: |
-          gcloud compute url-maps invalidate-cdn-cache releases-mondoo-io --path "/${{ inputs.reindex-path || '*' }}"
+          gcloud compute url-maps invalidate-cdn-cache releases-mondoo-io --path "/${REINDEX_PATH}"
   build-arch:
     uses: ./.github/workflows/pkg_arch-aur.yaml
     needs: [parse-inputs, reindex]

--- a/.github/workflows/pkg_published_trigger_build_release.yaml
+++ b/.github/workflows/pkg_published_trigger_build_release.yaml
@@ -159,8 +159,13 @@ jobs:
             echo "Invalid reindex-path: $REINDEX_PATH"
             exit 1
           fi
+          cache_invalidation_path="$REINDEX_PATH"
+          if [[ -z "$cache_invalidation_path" ]]; then
+            cache_invalidation_path="*"
+          fi
           printf 'bucket=%s\n' "$BUCKET" >> "$GITHUB_OUTPUT"
           printf 'reindex-path=%s\n' "$REINDEX_PATH" >> "$GITHUB_OUTPUT"
+          printf 'cache-invalidation-path=%s\n' "$cache_invalidation_path" >> "$GITHUB_OUTPUT"
       - name: "Authenticate to Google Cloud"
         uses: "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093" # v3.0.0
         with:
@@ -223,9 +228,9 @@ jobs:
           rm "$MINSTALLER.yaml"
       - name: Invalidate Google Load Balancer caches (ETA~10 minutes)
         env:
-          REINDEX_PATH: ${{ steps.inputs.outputs.reindex-path || '*' }}
+          CACHE_INVALIDATION_PATH: ${{ steps.inputs.outputs.cache-invalidation-path }}
         run: |
-          gcloud compute url-maps invalidate-cdn-cache releases-mondoo-io --path "/${REINDEX_PATH}"
+          gcloud compute url-maps invalidate-cdn-cache releases-mondoo-io --path "/${CACHE_INVALIDATION_PATH}"
   build-arch:
     uses: ./.github/workflows/pkg_arch-aur.yaml
     needs: [parse-inputs, reindex]

--- a/.github/workflows/release_mondoo_pkgs.yaml
+++ b/.github/workflows/release_mondoo_pkgs.yaml
@@ -59,8 +59,19 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ inputs.version }}
+      BUCKET: ${{ inputs.bucket }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Validate inputs
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $VERSION"
+            exit 1
+          fi
+          if [[ ! "$BUCKET" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "Invalid bucket name: $BUCKET"
+            exit 1
+          fi
       - name: Create destination folder
         run: |
           cd  helper
@@ -117,7 +128,7 @@ jobs:
         env:
           SKIP: ${{ inputs.skip-publish && 'echo skipping...' || '' }}
         run: |
-          $SKIP gsutil cp -r helper/packages/* gs://${{ inputs.bucket }}/mondoo/${{ inputs.version }}/
+          $SKIP gsutil cp -r helper/packages/* "gs://${BUCKET}/mondoo/${VERSION}/"
 
       - name: Upload files to GitHub Release Page
         if: ${{ !inputs.skip-publish }}

--- a/.github/workflows/test-released-all.yaml
+++ b/.github/workflows/test-released-all.yaml
@@ -99,9 +99,13 @@ jobs:
             echo "Name: ${INPUT_NAME}"
             echo "name=${INPUT_NAME}" >> $GITHUB_OUTPUT
           fi
-          V=$(echo $VERSION | sed 's/v//')
+          V="${VERSION#v}"
+          if [[ ! "$V" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $VERSION"
+            exit 1
+          fi
           echo "Version: $V"
-          echo "version=${V}" >> $GITHUB_OUTPUT
+          printf 'version=%s\n' "$V" >> "$GITHUB_OUTPUT"
       # wait for versioned ubi-rootless container image to be published, otherwise tests will fail directly
       # This may take some time, it one of the last images to be created
       # Chances are high, that most of the tests will pass on the first try with this.
@@ -109,6 +113,8 @@ jobs:
         if: github.event_name == 'release'
         id: check_release_file
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         with:
           retry_wait_seconds: 20
           timeout_seconds: 5
@@ -116,8 +122,8 @@ jobs:
           retry_on: error
           # error on HTTP code different to 200
           command: |
-            vSEMVER=${{ steps.version.outputs.version }}
-            SEMVER="${vSEMVER//v}"
+            vSEMVER="${VERSION}"
+            SEMVER="${vSEMVER#v}"
             curl -o /dev/null -s -w "%{http_code}\n" "https://registry.hub.docker.com/v2/repositories/mondoo/client/tags/${SEMVER}-ubi-rootless" | grep 200
 
   test-arch:

--- a/.github/workflows/test-released-archlinux.yaml
+++ b/.github/workflows/test-released-archlinux.yaml
@@ -28,11 +28,17 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Install mql with MakePKG on Arch Linux
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          docker run --rm -v $(pwd):/work -w /work archlinux:latest \
+          docker run --rm -e EXPECTED_VERSION -v "$(pwd):/work" -w /work archlinux:latest \
           bash -c "pacman -Syu --noconfirm && \
                     pacman -S --noconfirm base-devel git &&  \
                     cd /tmp && \
@@ -40,7 +46,7 @@ jobs:
                     su test -c \"git clone https://aur.archlinux.org/mql && cd mql && makepkg\" && \
                     cd  mql && \
                     pacman -U --noconfirm  mql-*.zst && \
-                    mql version | grep -q ${{ steps.version.outputs.version }}"
+                    mql version | grep -q \"\$EXPECTED_VERSION\""
       
   arch-cnspec-yay:
     runs-on: ubuntu-latest
@@ -51,11 +57,17 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Install cnspec with Yay on Arch Linux
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          docker run --rm -v $(pwd):/work -w /work archlinux:latest \
+          docker run --rm -e EXPECTED_VERSION -v "$(pwd):/work" -w /work archlinux:latest \
           bash -c " pacman -Syu --noconfirm && \
                     pacman -S --noconfirm base-devel git go &&  \
                     cd /tmp && \
@@ -65,8 +77,8 @@ jobs:
                     cd  yay && \
                     pacman -U --noconfirm  yay-*.zst && \
                     su test -c \"yay -S --noconfirm cnspec\" && \
-                    cnspec version | grep -q ${{ steps.version.outputs.version }} && \
-                    cnquery version | grep -q ${{ steps.version.outputs.version }}"
+                    cnspec version | grep -q \"\$EXPECTED_VERSION\" && \
+                    cnquery version | grep -q \"\$EXPECTED_VERSION\""
 
   # TODO: re-enable once the cnquery -> mql upgrade path works on Arch Linux
   # arch-upgrade-cnquery-to-mql:

--- a/.github/workflows/test-released-brew.yaml
+++ b/.github/workflows/test-released-brew.yaml
@@ -32,9 +32,15 @@ jobs:
           /bin/bash -c "$(curl --retry 10 --retry-delay 60 -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
       - name: Testing install of ${{ matrix.package }}....
+        env:
+          PACKAGE: ${{ matrix.package }}
         run: |
           brew tap mondoohq/mondoo
-          brew install ${{ matrix.package }}
+          if [[ "$PACKAGE" != "mql" && "$PACKAGE" != "cnspec" ]]; then
+            echo "Invalid package: $PACKAGE"
+            exit 1
+          fi
+          brew install "$PACKAGE"
 
       - name: Version
         id: version
@@ -49,13 +55,24 @@ jobs:
           printf 'package_version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Executing ${{ matrix.package }}....
+        env:
+          PACKAGE: ${{ matrix.package }}
         run: |
-          ${{ matrix.package }} version
+          if [[ "$PACKAGE" != "mql" && "$PACKAGE" != "cnspec" ]]; then
+            echo "Invalid package: $PACKAGE"
+            exit 1
+          fi
+          "$PACKAGE" version
       - name: Verify the correct version is installed
         env:
           EXPECTED_VERSION: ${{ steps.version.outputs.package_version }}
+          PACKAGE: ${{ matrix.package }}
         run: |
-          ${{ matrix.package }} version | grep -q "$EXPECTED_VERSION"
+          if [[ "$PACKAGE" != "mql" && "$PACKAGE" != "cnspec" ]]; then
+            echo "Invalid package: $PACKAGE"
+            exit 1
+          fi
+          "$PACKAGE" version | grep -q "$EXPECTED_VERSION"
 
   cask:
     runs-on: macos-latest

--- a/.github/workflows/test-released-brew.yaml
+++ b/.github/workflows/test-released-brew.yaml
@@ -41,15 +41,21 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "package_version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'package_version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Executing ${{ matrix.package }}....
         run: |
           ${{ matrix.package }} version
       - name: Verify the correct version is installed
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.package_version }}
         run: |
-          ${{ matrix.package }} version | grep -q ${{ steps.version.outputs.package_version}}
+          ${{ matrix.package }} version | grep -q "$EXPECTED_VERSION"
 
   cask:
     runs-on: macos-latest
@@ -68,11 +74,17 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "package_version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'package_version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Executing cnspec from Mondoo package....
         run: |
           /Library/Mondoo/bin/cnspec version
       - name: Verify the correct version is installed
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.package_version }}
         run: |
-          /Library/Mondoo/bin/cnspec version | grep -q ${{ steps.version.outputs.package_version}}
+          /Library/Mondoo/bin/cnspec version | grep -q "$EXPECTED_VERSION"

--- a/.github/workflows/test-released-docker.yaml
+++ b/.github/workflows/test-released-docker.yaml
@@ -41,8 +41,9 @@ jobs:
       - name: Testing mondoo/mql:${{ matrix.tag }}....
         env:
           EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+          IMAGE_TAG: ${{ matrix.tag }}
         run: |
-          version=$(docker run --rm -v $(pwd):/work -w /work mondoo/mql:${{ matrix.tag }} version)
+          version=$(docker run --rm -v "$(pwd):/work" -w /work "mondoo/mql:${IMAGE_TAG}" version)
           echo "$version"
           echo "$version" | grep -q "$EXPECTED_VERSION"
   cnspec-containers:
@@ -67,8 +68,9 @@ jobs:
       - name: Testing mondoo/cnspec:${{ matrix.tag }}....
         env:
           EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+          IMAGE_TAG: ${{ matrix.tag }}
         run: |
-          version=$(docker run --rm -v $(pwd):/work -w /work mondoo/cnspec:${{ matrix.tag }} version)
+          version=$(docker run --rm -v "$(pwd):/work" -w /work "mondoo/cnspec:${IMAGE_TAG}" version)
           echo "$version"
           echo "$version" | grep -q "$EXPECTED_VERSION"
 
@@ -94,7 +96,8 @@ jobs:
       - name: Testing mondoo/client:${{ matrix.tag }}....
         env:
           EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+          IMAGE_TAG: ${{ matrix.tag }}
         run: |
-          version=$(docker run --rm -v $(pwd):/work -w /work mondoo/client:${{ matrix.tag }} version)
+          version=$(docker run --rm -v "$(pwd):/work" -w /work "mondoo/client:${IMAGE_TAG}" version)
           echo "$version"
           echo "$version" | grep -q "$EXPECTED_VERSION"

--- a/.github/workflows/test-released-docker.yaml
+++ b/.github/workflows/test-released-docker.yaml
@@ -32,13 +32,19 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Testing mondoo/mql:${{ matrix.tag }}....
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
           version=$(docker run --rm -v $(pwd):/work -w /work mondoo/mql:${{ matrix.tag }} version)
-          echo $version
-          echo $version | grep -q ${{ steps.version.outputs.version }}
+          echo "$version"
+          echo "$version" | grep -q "$EXPECTED_VERSION"
   cnspec-containers:
     runs-on: ubuntu-latest
     strategy:
@@ -52,13 +58,19 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Testing mondoo/cnspec:${{ matrix.tag }}....
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
           version=$(docker run --rm -v $(pwd):/work -w /work mondoo/cnspec:${{ matrix.tag }} version)
-          echo $version
-          echo $version | grep -q ${{ steps.version.outputs.version }}
+          echo "$version"
+          echo "$version" | grep -q "$EXPECTED_VERSION"
 
   mondoo-containers:
     runs-on: ubuntu-latest
@@ -73,10 +85,16 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Testing mondoo/client:${{ matrix.tag }}....
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
           version=$(docker run --rm -v $(pwd):/work -w /work mondoo/client:${{ matrix.tag }} version)
-          echo $version
-          echo $version | grep -q ${{ steps.version.outputs.version }}
+          echo "$version"
+          echo "$version" | grep -q "$EXPECTED_VERSION"

--- a/.github/workflows/test-released-install-ps1.yaml
+++ b/.github/workflows/test-released-install-ps1.yaml
@@ -25,6 +25,9 @@ jobs:
       - name: Wait for packages to be published (Release Event)
         id: check_release_file
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          MINSTALLER_API_KEY: ${{ secrets.MINSTALLER_API_KEY }}
         with:
           retry_wait_seconds: 20
           timeout_seconds: 20
@@ -32,8 +35,8 @@ jobs:
           retry_on: error
           # error on HTTP code different to 200
           command: |
-            vSEMVER=${{ inputs.version }}
-            SEMVER="${vSEMVER//v}"
+            vSEMVER="${INPUT_VERSION}"
+            SEMVER="${vSEMVER#v}"
 
             # Clear cache before checking with retry logic
             echo "Clearing minstaller's cache..."
@@ -46,7 +49,7 @@ jobs:
 
               cache_response=$(curl -s -w "HTTP_CODE:%{http_code}" \
                 -X POST https://install.mondoo.com/_/cache/clear-all \
-                -H "X-API-Key: ${{ secrets.MINSTALLER_API_KEY }}" 2>/dev/null || true)
+                -H "X-API-Key: ${MINSTALLER_API_KEY}" 2>/dev/null || true)
 
               if echo "$cache_response" | grep -q "HTTP_CODE:200"; then
                 echo "✅ Cache cleared successfully on attempt $cache_attempt"
@@ -116,10 +119,16 @@ jobs:
           fetch-depth: 0
       - name: Version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          $v='${{ inputs.version }}'
-          $version=$v.trim("v","V")
-          echo "version=$version" >> $env:GITHUB_OUTPUT
+          $v=$env:INPUT_VERSION
+          $version=$v.TrimStart("v", "V")
+          if ($version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$') {
+            Write-Error "Invalid version: $v"
+            exit 1
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
       - name: Check if install.ps1 changed
         id: check_install_ps1
         shell: bash
@@ -145,9 +154,11 @@ jobs:
           Install-Mondoo -Product ${{ matrix.package }};
       - name: Verify the correct version is installed
         shell: pwsh
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
           # Logic to validate version has been moved to separate file
-          ./test/powershell/verify-cnspec-version.ps1 -ExpectedVersion "${{ steps.version.outputs.version }}"  -BinaryBaseName "${{ matrix.package }}"
+          ./test/powershell/verify-cnspec-version.ps1 -ExpectedVersion "$env:EXPECTED_VERSION"  -BinaryBaseName "${{ matrix.package }}"
 
   install-ps1-windows-mondoo:
     runs-on: windows-latest
@@ -162,10 +173,16 @@ jobs:
           fetch-depth: 0
       - name: Version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          $v='${{ inputs.version }}'
-          $version=$v.trim("v","V")
-          echo "version=$version" >> $env:GITHUB_OUTPUT
+          $v=$env:INPUT_VERSION
+          $version=$v.TrimStart("v", "V")
+          if ($version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$') {
+            Write-Error "Invalid version: $v"
+            exit 1
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
       - name: Check if install.ps1 changed
         id: check_install_ps1
         shell: bash
@@ -191,9 +208,11 @@ jobs:
           Install-Mondoo -Product ${{ matrix.package }};
       - name: Verify the correct version is installed
         shell: pwsh
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
           # Logic to validate version has been moved to separate file
-          ./test/powershell/verify-cnspec-version.ps1 -ExpectedVersion "${{ steps.version.outputs.version }}"
+          ./test/powershell/verify-cnspec-version.ps1 -ExpectedVersion "$env:EXPECTED_VERSION"
 
   upgrade-from-cnquery-ps1:
     runs-on: windows-latest
@@ -204,10 +223,16 @@ jobs:
           fetch-depth: 0
       - name: Version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          $v='${{ inputs.version }}'
-          $version=$v.trim("v","V")
-          echo "version=$version" >> $env:GITHUB_OUTPUT
+          $v=$env:INPUT_VERSION
+          $version=$v.TrimStart("v", "V")
+          if ($version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$') {
+            Write-Error "Invalid version: $v"
+            exit 1
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
       - name: Install cnquery (old package) via install.ps1
         run: |
           Set-ExecutionPolicy Unrestricted -Scope Process -Force;
@@ -240,8 +265,10 @@ jobs:
           Install-Mondoo -Product mql;
       - name: Verify mql is installed at the expected version
         shell: pwsh
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          ./test/powershell/verify-cnspec-version.ps1 -ExpectedVersion "${{ steps.version.outputs.version }}" -BinaryBaseName "mql"
+          ./test/powershell/verify-cnspec-version.ps1 -ExpectedVersion "$env:EXPECTED_VERSION" -BinaryBaseName "mql"
       # TODO: re-enable once cnquery.exe is updated by the mql upgrade
       # - name: Verify cnquery.exe points to cnspec (backward compat)
       #   run: |

--- a/.github/workflows/test-released-install-ps1.yaml
+++ b/.github/workflows/test-released-install-ps1.yaml
@@ -141,24 +141,33 @@ jobs:
             echo "install.ps1 has not changed compared to main"
           fi
       - name: Install.ps1/${{ matrix.package }} on ${{ matrix.os }}
+        env:
+          PACKAGE: ${{ matrix.package }}
+          INSTALL_PS1_CHANGED: ${{ steps.check_install_ps1.outputs.changed }}
         run: |
+          $product = $env:PACKAGE
+          if (@("mql", "cnspec") -notcontains $product) {
+            Write-Error "Invalid package: $product"
+            exit 1
+          }
           Set-ExecutionPolicy Unrestricted -Scope Process -Force;
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
-          if ('${{ steps.check_install_ps1.outputs.changed }}' -eq 'true') {
+          if ($env:INSTALL_PS1_CHANGED -eq 'true') {
             Write-Host "Using local install.ps1 from repository"
             . .\install.ps1
           } else {
             Write-Host "Using install.ps1 from install.mondoo.com"
-            iex ((New-Object System.Net.WebClient).DownloadString('https://install.mondoo.com/ps1/${{ matrix.package }}'));
+            iex ((New-Object System.Net.WebClient).DownloadString("https://install.mondoo.com/ps1/$product"));
           }
-          Install-Mondoo -Product ${{ matrix.package }};
+          Install-Mondoo -Product $product;
       - name: Verify the correct version is installed
         shell: pwsh
         env:
           EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+          BINARY_BASE_NAME: ${{ matrix.package }}
         run: |
           # Logic to validate version has been moved to separate file
-          ./test/powershell/verify-cnspec-version.ps1 -ExpectedVersion "$env:EXPECTED_VERSION"  -BinaryBaseName "${{ matrix.package }}"
+          ./test/powershell/verify-cnspec-version.ps1 -ExpectedVersion "$env:EXPECTED_VERSION"  -BinaryBaseName "$env:BINARY_BASE_NAME"
 
   install-ps1-windows-mondoo:
     runs-on: windows-latest
@@ -195,17 +204,25 @@ jobs:
             echo "install.ps1 has not changed compared to main"
           fi
       - name: Install.ps1/${{ matrix.package }} on ${{ matrix.os }}
+        env:
+          PACKAGE: ${{ matrix.package }}
+          INSTALL_PS1_CHANGED: ${{ steps.check_install_ps1.outputs.changed }}
         run: |
+          $product = $env:PACKAGE
+          if ($product -ne "mondoo") {
+            Write-Error "Invalid package: $product"
+            exit 1
+          }
           Set-ExecutionPolicy Unrestricted -Scope Process -Force;
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
-          if ('${{ steps.check_install_ps1.outputs.changed }}' -eq 'true') {
+          if ($env:INSTALL_PS1_CHANGED -eq 'true') {
             Write-Host "Using local install.ps1 from repository"
             . .\install.ps1
           } else {
             Write-Host "Using install.ps1 from install.mondoo.com"
-            iex ((New-Object System.Net.WebClient).DownloadString('https://install.mondoo.com/ps1/${{ matrix.package }}'));
+            iex ((New-Object System.Net.WebClient).DownloadString("https://install.mondoo.com/ps1/$product"));
           }
-          Install-Mondoo -Product ${{ matrix.package }};
+          Install-Mondoo -Product $product;
       - name: Verify the correct version is installed
         shell: pwsh
         env:

--- a/.github/workflows/test-released-install-sh.yaml
+++ b/.github/workflows/test-released-install-sh.yaml
@@ -85,12 +85,22 @@ jobs:
       - name: Install.sh/${{ matrix.package }} on ${{ matrix.distro }}
         env:
           EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+          PACKAGE: ${{ matrix.package }}
+          DISTRO: ${{ matrix.distro }}
         run: |
-          docker run --rm -e EXPECTED_VERSION -v "$(pwd):/work" -w /work ${{ matrix.distro }} \
-          bash -c "apt-get update && apt-get install -y curl && \
-            curl -sSL https://install.mondoo.com/sh/${{ matrix.package }} | bash -x - && \
-            ${{ matrix.package }} version | grep -q \"\$EXPECTED_VERSION\" && \
-            if [ '${{ matrix.package }}' = 'cnspec' ]; then cnquery version | grep -q \"\$EXPECTED_VERSION\"; fi"
+          if [[ "$PACKAGE" != "mql" && "$PACKAGE" != "cnspec" ]]; then
+            echo "Invalid package: $PACKAGE"
+            exit 1
+          fi
+          if [[ ! "$DISTRO" =~ ^[A-Za-z0-9._/@:-]+$ ]]; then
+            echo "Invalid distro: $DISTRO"
+            exit 1
+          fi
+          docker run --rm -e EXPECTED_VERSION -e PACKAGE -v "$(pwd):/work" -w /work "$DISTRO" \
+          bash -c 'apt-get update && apt-get install -y curl && \
+            curl -sSL "https://install.mondoo.com/sh/${PACKAGE}" | bash -x - && \
+            "$PACKAGE" version | grep -q "$EXPECTED_VERSION" && \
+            if [ "$PACKAGE" = "cnspec" ]; then cnquery version | grep -q "$EXPECTED_VERSION"; fi'
 
   install-sh-yum:
     runs-on: ubuntu-latest
@@ -129,11 +139,21 @@ jobs:
       - name: Install.sh/${{ matrix.package }} on ${{ matrix.distro }}
         env:
           EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+          PACKAGE: ${{ matrix.package }}
+          DISTRO: ${{ matrix.distro }}
         run: |
-          docker run --rm -e EXPECTED_VERSION -v "$(pwd):/work" -w /work ${{ matrix.distro }} \
-          bash -c "curl -sSL https://install.mondoo.com/sh/${{ matrix.package }} | bash - && \
-            ${{ matrix.package }} version | grep -q \"\$EXPECTED_VERSION\" && \
-            if [ '${{ matrix.package }}' = 'cnspec' ]; then cnquery version | grep -q \"\$EXPECTED_VERSION\"; fi"
+          if [[ "$PACKAGE" != "mql" && "$PACKAGE" != "cnspec" ]]; then
+            echo "Invalid package: $PACKAGE"
+            exit 1
+          fi
+          if [[ ! "$DISTRO" =~ ^[A-Za-z0-9._/@:-]+$ ]]; then
+            echo "Invalid distro: $DISTRO"
+            exit 1
+          fi
+          docker run --rm -e EXPECTED_VERSION -e PACKAGE -v "$(pwd):/work" -w /work "$DISTRO" \
+          bash -c 'curl -sSL "https://install.mondoo.com/sh/${PACKAGE}" | bash - && \
+            "$PACKAGE" version | grep -q "$EXPECTED_VERSION" && \
+            if [ "$PACKAGE" = "cnspec" ]; then cnquery version | grep -q "$EXPECTED_VERSION"; fi'
 
   install-sh-zypper:
     runs-on: ubuntu-latest
@@ -162,12 +182,22 @@ jobs:
       - name: Install.sh/${{ matrix.package }} on ${{ matrix.distro }}
         env:
           EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+          PACKAGE: ${{ matrix.package }}
+          DISTRO: ${{ matrix.distro }}
         run: |
-          docker run --rm -e EXPECTED_VERSION -v "$(pwd):/work" -w /work ${{ matrix.distro }} \
-          bash -c "zypper -n install curl && \
-            curl -sSL https://install.mondoo.com/sh/${{ matrix.package }} | bash - && \
-            ${{ matrix.package }} version | grep -q \"\$EXPECTED_VERSION\" && \
-            if [ '${{ matrix.package }}' = 'cnspec' ]; then cnquery version | grep -q \"\$EXPECTED_VERSION\"; fi"
+          if [[ "$PACKAGE" != "mql" && "$PACKAGE" != "cnspec" ]]; then
+            echo "Invalid package: $PACKAGE"
+            exit 1
+          fi
+          if [[ ! "$DISTRO" =~ ^[A-Za-z0-9._/@:-]+$ ]]; then
+            echo "Invalid distro: $DISTRO"
+            exit 1
+          fi
+          docker run --rm -e EXPECTED_VERSION -e PACKAGE -v "$(pwd):/work" -w /work "$DISTRO" \
+          bash -c 'zypper -n install curl && \
+            curl -sSL "https://install.mondoo.com/sh/${PACKAGE}" | bash - && \
+            "$PACKAGE" version | grep -q "$EXPECTED_VERSION" && \
+            if [ "$PACKAGE" = "cnspec" ]; then cnquery version | grep -q "$EXPECTED_VERSION"; fi'
 
   install-sh-macos:
     runs-on: macos-latest
@@ -190,14 +220,26 @@ jobs:
           fi
           printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Install.sh/${{ matrix.package }} on ${{ matrix.os }}
+        env:
+          PACKAGE: ${{ matrix.package }}
         run: |
-          bash -c "$(curl -sSL https://install.mondoo.com/sh/${{ matrix.package }})"
-          ${{ matrix.package }} version
+          if [[ "$PACKAGE" != "mql" && "$PACKAGE" != "cnspec" ]]; then
+            echo "Invalid package: $PACKAGE"
+            exit 1
+          fi
+          installer_url="https://install.mondoo.com/sh/${PACKAGE}"
+          bash -c "$(curl -sSL "$installer_url")"
+          "$PACKAGE" version
       - name: Verify the correct version is installed
         env:
           EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+          PACKAGE: ${{ matrix.package }}
         run: |
-          ${{ matrix.package }} version | grep -q "$EXPECTED_VERSION"
+          if [[ "$PACKAGE" != "mql" && "$PACKAGE" != "cnspec" ]]; then
+            echo "Invalid package: $PACKAGE"
+            exit 1
+          fi
+          "$PACKAGE" version | grep -q "$EXPECTED_VERSION"
       - name: Verify cnquery symlink points to cnspec (cnspec only)
         if: matrix.package == 'cnspec'
         env:
@@ -235,8 +277,13 @@ jobs:
       - name: Upgrade cnquery -> mql on ${{ matrix.distro }}
         env:
           EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+          DISTRO: ${{ matrix.distro }}
         run: |
-          docker run --rm -e EXPECTED_VERSION -v "$(pwd):/work" -w /work ${{ matrix.distro }} \
+          if [[ ! "$DISTRO" =~ ^[A-Za-z0-9._/@:-]+$ ]]; then
+            echo "Invalid distro: $DISTRO"
+            exit 1
+          fi
+          docker run --rm -e EXPECTED_VERSION -v "$(pwd):/work" -w /work "$DISTRO" \
           bash -c "set -e && \
             echo '==> Installing curl...' && \
             apt-get update && apt-get install -y curl && \

--- a/.github/workflows/test-released-install-sh.yaml
+++ b/.github/workflows/test-released-install-sh.yaml
@@ -25,6 +25,9 @@ jobs:
       - name: Wait for packages to be published (Release Event)
         id: check_release_file
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          MINSTALLER_API_KEY: ${{ secrets.MINSTALLER_API_KEY }}
         with:
           retry_wait_seconds: 20
           timeout_seconds: 5
@@ -32,14 +35,14 @@ jobs:
           retry_on: error
           # error on HTTP code different to 200
           command: |
-            vSEMVER=${{ inputs.version }}
-            SEMVER="${vSEMVER//v}"
+            vSEMVER="${INPUT_VERSION}"
+            SEMVER="${vSEMVER#v}"
 
             # Clear cache before checking (ignore failures)
             echo "Clearing minstaller's cache..."
             cache_response=$(curl -s -w "HTTP_CODE:%{http_code}" \
               -X POST https://install.mondoo.com/_/cache/clear-all \
-              -H "X-API-Key: ${{ secrets.MINSTALLER_API_KEY }}" 2>/dev/null || true)
+              -H "X-API-Key: ${MINSTALLER_API_KEY}" 2>/dev/null || true)
 
             if echo "$cache_response" | grep -q "HTTP_CODE:200"; then
               echo "✅ Cache cleared successfully"
@@ -73,15 +76,21 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Install.sh/${{ matrix.package }} on ${{ matrix.distro }}
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          docker run --rm -v $(pwd):/work -w /work ${{ matrix.distro }} \
+          docker run --rm -e EXPECTED_VERSION -v "$(pwd):/work" -w /work ${{ matrix.distro }} \
           bash -c "apt-get update && apt-get install -y curl && \
             curl -sSL https://install.mondoo.com/sh/${{ matrix.package }} | bash -x - && \
-            ${{ matrix.package }} version | grep -q ${{ steps.version.outputs.version }} && \
-            if [ '${{ matrix.package }}' = 'cnspec' ]; then cnquery version | grep -q ${{ steps.version.outputs.version }}; fi"
+            ${{ matrix.package }} version | grep -q \"\$EXPECTED_VERSION\" && \
+            if [ '${{ matrix.package }}' = 'cnspec' ]; then cnquery version | grep -q \"\$EXPECTED_VERSION\"; fi"
 
   install-sh-yum:
     runs-on: ubuntu-latest
@@ -111,14 +120,20 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Install.sh/${{ matrix.package }} on ${{ matrix.distro }}
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          docker run --rm -v $(pwd):/work -w /work ${{ matrix.distro }} \
+          docker run --rm -e EXPECTED_VERSION -v "$(pwd):/work" -w /work ${{ matrix.distro }} \
           bash -c "curl -sSL https://install.mondoo.com/sh/${{ matrix.package }} | bash - && \
-            ${{ matrix.package }} version | grep -q ${{ steps.version.outputs.version }} && \
-            if [ '${{ matrix.package }}' = 'cnspec' ]; then cnquery version | grep -q ${{ steps.version.outputs.version }}; fi"
+            ${{ matrix.package }} version | grep -q \"\$EXPECTED_VERSION\" && \
+            if [ '${{ matrix.package }}' = 'cnspec' ]; then cnquery version | grep -q \"\$EXPECTED_VERSION\"; fi"
 
   install-sh-zypper:
     runs-on: ubuntu-latest
@@ -138,15 +153,21 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Install.sh/${{ matrix.package }} on ${{ matrix.distro }}
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          docker run --rm -v $(pwd):/work -w /work ${{ matrix.distro }} \
+          docker run --rm -e EXPECTED_VERSION -v "$(pwd):/work" -w /work ${{ matrix.distro }} \
           bash -c "zypper -n install curl && \
             curl -sSL https://install.mondoo.com/sh/${{ matrix.package }} | bash - && \
-            ${{ matrix.package }} version | grep -q ${{ steps.version.outputs.version }} && \
-            if [ '${{ matrix.package }}' = 'cnspec' ]; then cnquery version | grep -q ${{ steps.version.outputs.version }}; fi"
+            ${{ matrix.package }} version | grep -q \"\$EXPECTED_VERSION\" && \
+            if [ '${{ matrix.package }}' = 'cnspec' ]; then cnquery version | grep -q \"\$EXPECTED_VERSION\"; fi"
 
   install-sh-macos:
     runs-on: macos-latest
@@ -162,19 +183,27 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Install.sh/${{ matrix.package }} on ${{ matrix.os }}
         run: |
           bash -c "$(curl -sSL https://install.mondoo.com/sh/${{ matrix.package }})"
           ${{ matrix.package }} version
       - name: Verify the correct version is installed
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          ${{ matrix.package }} version | grep -q ${{ steps.version.outputs.version }}
+          ${{ matrix.package }} version | grep -q "$EXPECTED_VERSION"
       - name: Verify cnquery symlink points to cnspec (cnspec only)
         if: matrix.package == 'cnspec'
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          cnquery version | grep -q ${{ steps.version.outputs.version }}
+          cnquery version | grep -q "$EXPECTED_VERSION"
 
   upgrade-from-cnquery-apt:
     runs-on: ubuntu-latest
@@ -197,11 +226,17 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Upgrade cnquery -> mql on ${{ matrix.distro }}
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          docker run --rm -v $(pwd):/work -w /work ${{ matrix.distro }} \
+          docker run --rm -e EXPECTED_VERSION -v "$(pwd):/work" -w /work ${{ matrix.distro }} \
           bash -c "set -e && \
             echo '==> Installing curl...' && \
             apt-get update && apt-get install -y curl && \
@@ -212,7 +247,7 @@ jobs:
             echo '==> Installing mql (should replace cnquery)...' && \
             curl -sSL https://install.mondoo.com/sh/mql | bash -x - && \
             echo '==> Verifying mql version...' && \
-            mql version | grep -q ${{ steps.version.outputs.version }} && \
+            mql version | grep -q \"\$EXPECTED_VERSION\" && \
             echo '==> Verifying cnquery was removed...' && \
             if dpkg -l 2>/dev/null | awk '/^ii/{print \$2}' | grep -qx cnquery; then echo 'ERROR: cnquery should have been removed but is still installed'; exit 1; fi && \
             echo '==> SUCCESS: cnquery was properly replaced by mql'"

--- a/.github/workflows/test-released-osx-pkg.yaml
+++ b/.github/workflows/test-released-osx-pkg.yaml
@@ -28,24 +28,38 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION="${INPUT_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION"
+            exit 1
+          fi
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Download Package
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          curl -SL -O https://releases.mondoo.com/mondoo/${{ steps.version.outputs.version }}/mondoo_${{ steps.version.outputs.version }}_darwin_universal.pkg
+          curl -SL -O "https://releases.mondoo.com/mondoo/${VERSION}/mondoo_${VERSION}_darwin_universal.pkg"
       - name: Install Package
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          sudo installer -pkg mondoo_${{ steps.version.outputs.version }}_darwin_universal.pkg -target /
+          sudo installer -pkg "mondoo_${VERSION}_darwin_universal.pkg" -target /
 
       - name: Executing cnspec...
         run: |
           /Library/Mondoo/bin/cnspec version
       - name: Verify the correct version is installed
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          /Library/Mondoo/bin/cnspec version | grep ${{ steps.version.outputs.version }}
+          /Library/Mondoo/bin/cnspec version | grep "$EXPECTED_VERSION"
       - name: Verify mql is installed
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          /Library/Mondoo/bin/mql version | grep ${{ steps.version.outputs.version }}
+          /Library/Mondoo/bin/mql version | grep "$EXPECTED_VERSION"
       - name: Verify cnquery symlink points to cnspec
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          /Library/Mondoo/bin/cnquery version | grep ${{ steps.version.outputs.version }}
+          /Library/Mondoo/bin/cnquery version | grep "$EXPECTED_VERSION"

--- a/.github/workflows/test_linux_packaging.yml
+++ b/.github/workflows/test_linux_packaging.yml
@@ -47,10 +47,17 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Run mondoo-pkg and upgrade tests
+        env:
+          VERSION: ${{ inputs.version }}
+          RELEASES_URL: ${{ inputs.releases-url || 'https://releases.mondoo.love' }}
         run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $VERSION"
+            exit 1
+          fi
           python3 test/auto_update/test_auto_update.py \
-            --install-version "${{ inputs.version }}" \
-            --releases-url "${{ inputs.releases-url || 'https://releases.mondoo.love' }}" \
+            --install-version "$VERSION" \
+            --releases-url "$RELEASES_URL" \
             --skip-auto-update \
             --skip-self-upgrade
 
@@ -63,10 +70,17 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Run auto-update tests
+        env:
+          VERSION: ${{ inputs.version }}
+          RELEASES_URL: ${{ inputs.releases-url || 'https://releases.mondoo.love' }}
         run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $VERSION"
+            exit 1
+          fi
           python3 test/auto_update/test_auto_update.py \
-            --install-version "${{ inputs.version }}" \
-            --releases-url "${{ inputs.releases-url || 'https://releases.mondoo.love' }}" \
+            --install-version "$VERSION" \
+            --releases-url "$RELEASES_URL" \
             --skip-mondoo-pkg \
             --skip-upgrade \
             --skip-self-upgrade
@@ -81,11 +95,23 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Run self-upgrade tests
+        env:
+          VERSION: ${{ inputs.version }}
+          RELEASES_URL: ${{ inputs.releases-url || 'https://releases.mondoo.love' }}
+          SELF_UPGRADE_FROM: ${{ inputs.self-upgrade-from }}
         run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $VERSION"
+            exit 1
+          fi
+          if [[ -n "$SELF_UPGRADE_FROM" && ! "$SELF_UPGRADE_FROM" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid self-upgrade-from version: $SELF_UPGRADE_FROM"
+            exit 1
+          fi
           python3 test/auto_update/test_auto_update.py \
-            --install-version "${{ inputs.version }}" \
-            --releases-url "${{ inputs.releases-url || 'https://releases.mondoo.love' }}" \
+            --install-version "$VERSION" \
+            --releases-url "$RELEASES_URL" \
             --skip-auto-update \
             --skip-mondoo-pkg \
             --skip-upgrade \
-            --self-upgrade-from "${{ inputs.self-upgrade-from }}"
+            --self-upgrade-from "$SELF_UPGRADE_FROM"

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -43,7 +43,7 @@ jobs:
             echo "Invalid version: $VERSION"
             exit 1
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Commit VERSION file
         run: |
           echo ${VERSION} > VERSION


### PR DESCRIPTION
Summary:
- route workflow inputs through environment variables before shell/PowerShell use
- validate semver, numeric retry, bucket/name, and reindex path inputs
- remove direct input interpolation from audited run/command blocks

Validation:
- ruby YAML parse for all workflows
- git diff --check
- scanner confirmed no inputs/github.event.inputs/parsed outputs/version outputs in run blocks