### PR TITLE
Fix Arch AUR dependency generation

### DIFF
--- a/packages/archlinux/README.md
+++ b/packages/archlinux/README.md
@@ -34,10 +34,10 @@ We highly recommend using one of the [AUR_helpers](https://wiki.archlinux.org/ti
 
 ```bash
 # install mql
-yay -Ss mql
+yay -S mql
 
 # install cnspec
-yay -Ss cnspec
+yay -S cnspec
 ```
 
 # Test github action

--- a/packages/archlinux/generator/main.go
+++ b/packages/archlinux/generator/main.go
@@ -237,10 +237,12 @@ source=(
     {{ end -}}
 )
 arch=('x86_64')
-depends=({{ range .Depends }}'{{ . }}'{{ end }})
+depends=({{ pkgbuildArray .Depends }})
 {{ if .Conflicts -}}
-conflicts=({{ range .Conflicts }}'{{ . }}'{{ end }})
-replaces=({{ range .Replaces }}'{{ . }}'{{ end }})
+conflicts=({{ pkgbuildArray .Conflicts }})
+{{ end -}}
+{{ if .Replaces -}}
+replaces=({{ pkgbuildArray .Replaces }})
 {{ end -}}
 
 sha256sums=({{- if .BinFile }}'{{ .Sha256 }}'{{- end }}
@@ -267,8 +269,18 @@ package() {
 #vim: syntax=sh`
 
 func renderPkgBuild(b PkgBuild, out io.Writer) error {
-	t := template.Must(template.New("formula").Parse(pkgBuildTemplate))
+	t := template.Must(template.New("formula").Funcs(template.FuncMap{
+		"pkgbuildArray": pkgbuildArray,
+	}).Parse(pkgBuildTemplate))
 	return t.Execute(out, b)
+}
+
+func pkgbuildArray(values []string) string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, "'"+strings.ReplaceAll(value, "'", "'\"'\"'")+"'")
+	}
+	return strings.Join(quoted, " ")
 }
 
 var pkgSourceInfoTemplate = `pkgbase = {{ .PkgName }}
@@ -278,11 +290,18 @@ pkgrel = 1
 url = https://mondoo.com
 arch = x86_64
 license = {{ .License }}
+{{ range .Depends -}}
+depends = {{ . }}
+{{ end -}}
+{{- if .BinFile }}
 source = https://releases.mondoo.com/{{ .PkgName }}/{{ .Version }}/{{ .PkgName }}_{{ .Version }}_linux_amd64.tar.gz
+{{ end -}}
 {{ range .ExtraFiles -}}
 source = {{ .Name }}
 {{ end }}
+{{- if .BinFile }}
 sha256sums = {{ .Sha256 }}
+{{ end -}}
 {{ range .ExtraSha256 -}}
 sha256sums = {{ . }}
 {{ end }}

--- a/packages/archlinux/generator/main_test.go
+++ b/packages/archlinux/generator/main_test.go
@@ -1,0 +1,127 @@
+// Copyright Mondoo, Inc. 2025, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderPkgBuildSeparatesArrayValues(t *testing.T) {
+	var out strings.Builder
+	err := renderPkgBuild(PkgBuild{
+		Product: Product{
+			PkgName:   "mondoo",
+			License:   "custom",
+			Depends:   []string{"cnspec", "mql"},
+			Conflicts: []string{"cnquery", "legacy-mondoo"},
+			Replaces:  []string{"cnquery", "legacy-mondoo"},
+		},
+		Version: "13.11.0",
+	}, &out)
+	if err != nil {
+		t.Fatalf("renderPkgBuild() error = %v", err)
+	}
+
+	rendered := out.String()
+	for _, want := range []string{
+		"depends=('cnspec' 'mql')",
+		"conflicts=('cnquery' 'legacy-mondoo')",
+		"replaces=('cnquery' 'legacy-mondoo')",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered PKGBUILD does not contain %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestRenderPkgBuildEscapesArrayValues(t *testing.T) {
+	if got, want := pkgbuildArray([]string{"normal", "contains'quote"}), "'normal' 'contains'\"'\"'quote'"; got != want {
+		t.Fatalf("pkgbuildArray() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderPkgBuildSeparatesConflictsAndReplaces(t *testing.T) {
+	tests := []struct {
+		name     string
+		product  Product
+		want     string
+		dontWant string
+	}{
+		{
+			name: "conflicts without replaces",
+			product: Product{
+				PkgName:   "mondoo",
+				License:   "custom",
+				Conflicts: []string{"cnquery"},
+			},
+			want:     "conflicts=('cnquery')",
+			dontWant: "replaces=",
+		},
+		{
+			name: "replaces without conflicts",
+			product: Product{
+				PkgName:  "mondoo",
+				License:  "custom",
+				Replaces: []string{"cnquery"},
+			},
+			want:     "replaces=('cnquery')",
+			dontWant: "conflicts=",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var out strings.Builder
+			err := renderPkgBuild(PkgBuild{
+				Product: test.product,
+				Version: "13.11.0",
+			}, &out)
+			if err != nil {
+				t.Fatalf("renderPkgBuild() error = %v", err)
+			}
+
+			rendered := out.String()
+			if !strings.Contains(rendered, test.want) {
+				t.Fatalf("rendered PKGBUILD does not contain %q:\n%s", test.want, rendered)
+			}
+			if strings.Contains(rendered, test.dontWant) {
+				t.Fatalf("rendered PKGBUILD unexpectedly contains %q:\n%s", test.dontWant, rendered)
+			}
+		})
+	}
+}
+
+func TestRenderSrcInfoIncludesDependencies(t *testing.T) {
+	var out strings.Builder
+	err := renderScrInfo(PkgBuild{
+		Product: Product{
+			PkgName: "mondoo",
+			License: "custom",
+			Depends: []string{"cnspec", "mql"},
+			ExtraFiles: []SourceFile{
+				{Name: "mondoo.sh"},
+			},
+		},
+		Version: "13.11.0",
+	}, &out)
+	if err != nil {
+		t.Fatalf("renderScrInfo() error = %v", err)
+	}
+
+	rendered := out.String()
+	for _, want := range []string{
+		"depends = cnspec",
+		"depends = mql",
+		"source = mondoo.sh",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered .SRCINFO does not contain %q:\n%s", want, rendered)
+		}
+	}
+
+	if strings.Contains(rendered, "mondoo_13.11.0_linux_amd64.tar.gz") {
+		t.Fatalf("rendered .SRCINFO contains binary source for non-binary package:\n%s", rendered)
+	}
+}


### PR DESCRIPTION
## Summary
- render Arch PKGBUILD arrays with separators so mondoo depends on cnspec and mql separately
- include dependency metadata in generated .SRCINFO and avoid non-binary source entries for the mondoo wrapper
- add generator tests and fix Arch README yay install examples

## Verification
- GOCACHE=/tmp/mondoo-installer-go-build go test ./...
- git diff --check
- generated mondoo PKGBUILD locally and validated with makepkg --printsrcinfo
- built local package with makepkg -d -f and confirmed pacman -Qip reports Depends On: cnspec  mql