### PR TITLE
🐛 Fix -IdDetector breaking the Windows updater scheduled task

### DIFF
--- a/.github/workflows/test_powershell_pester.yml
+++ b/.github/workflows/test_powershell_pester.yml
@@ -1,0 +1,44 @@
+name: PowerShell Unit Tests
+
+on:
+  workflow_dispatch: # Allows manual triggering
+  pull_request:
+    paths:
+      - "install.ps1"
+      - "test/**.Tests.ps1"
+      - ".github/workflows/test_powershell_pester.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  pester:
+    name: Pester (install.ps1)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Install Pester
+        shell: pwsh
+        run: Install-Module -Name Pester -MinimumVersion 5.5.0 -Force -Scope CurrentUser -SkipPublisherCheck
+
+      - name: Run Pester tests
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Import-Module Pester -MinimumVersion 5.5.0
+          $config = New-PesterConfiguration
+          $config.Run.Path = './test'
+          $config.Run.Exit = $true          # non-zero exit on failure -> fails the job
+          $config.Output.Verbosity = 'Detailed'
+          $config.TestResult.Enabled = $true
+          $config.TestResult.OutputPath = 'pester-results.xml'
+          Invoke-Pester -Configuration $config
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pester-results
+          path: pester-results.xml

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ packages/archlinux/cnspec
 
 # OS caches
 .DS_Store
+
+# PowerShell Pester Reports - custom and default
+pester-results.xml
+testResults.xml

--- a/Makefile
+++ b/Makefile
@@ -168,11 +168,13 @@ test/download_sh:
 
 .PHONY: test/powershell
 test/powershell:
-	pwsh -Command "Install-Module -Name PSScriptAnalyzer"
-	pwsh -Command "Invoke-ScriptAnalyzer -Path .\install.ps1"
-	pwsh -Command "Invoke-ScriptAnalyzer -Path .\download.ps1"
-	pwsh -Command "Invoke-ScriptAnalyzer -Path .\powershell/Mondoo.Installer/Mondoo.Installer.psm1"
-	pwsh -Command "Test-ModuleManifest -Path ".\powershell\Mondoo.Installer\Mondoo.Installer.psd1""
+	pwsh -Command "if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer | Where-Object Version -ge ([version]'1.24.0'))) { Install-Module -Name PSScriptAnalyzer -MinimumVersion 1.24.0 -Force -Scope CurrentUser -SkipPublisherCheck }"
+	pwsh -Command "Invoke-ScriptAnalyzer -Path ./install.ps1"
+	pwsh -Command "Invoke-ScriptAnalyzer -Path ./download.ps1"
+	pwsh -Command "Invoke-ScriptAnalyzer -Path ./powershell/Mondoo.Installer/Mondoo.Installer.psm1"
+	pwsh -Command "Test-ModuleManifest -Path ./powershell/Mondoo.Installer/Mondoo.Installer.psd1"
+	pwsh -Command "if (-not (Get-Module -ListAvailable -Name Pester | Where-Object Version -ge ([version]'5.5.0'))) { Install-Module -Name Pester -MinimumVersion 5.5.0 -Force -Scope CurrentUser -SkipPublisherCheck }"
+	pwsh -Command "Invoke-Pester -Path ./test -CI"
 
 # Copywrite Check Tool: https://github.com/hashicorp/copywrite
 license: license/headers/check

--- a/install.ps1
+++ b/install.ps1
@@ -326,50 +326,21 @@ function Install-Mondoo {
       info " * Create and register the Mondoo update task"
       NewScheduledTaskFolder $taskpath
 
-      # Start building the command string
-      $command = @(
-        '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;'
-        '$wc = New-Object Net.Webclient;'
-      )
-
-      if (![string]::IsNullOrEmpty($Proxy)) {
-        $command += '$wc.proxy = New-Object System.Net.WebProxy(' + "'$Proxy'" + ');'
+      # Build the task argument via the pure helper so the (fragile) quoting is
+      # unit-tested off-Windows. See Get-MondooUpdaterTaskArgument and test/install.Tests.ps1.
+      $taskArgs = @{
+        Product    = $Product
+        Path       = $Path
+        Service    = $Service
+        Annotation = $Annotation
+        Name       = $Name
+        IdDetector = $script:NormalizedIdDetectors
+        Proxy      = $Proxy
+        UpdateTask = $UpdateTask
+        Time       = $Time
+        Interval   = $Interval
       }
-
-      $command += 'iex ($wc.DownloadString(' + "'https://install.mondoo.com/ps1'" + '));'
-
-      # Start building the Install-Mondoo command
-      $installCmd = @("Install-Mondoo")
-      $installCmd += "-Product $Product"
-      $installCmd += "-Path '$Path'"
-
-      if ($Service.ToLower() -eq 'enable' -and $Product.ToLower() -eq 'mondoo') {
-        $installCmd += "-Service enable"
-      }
-      if (![string]::IsNullOrEmpty($Annotation)) {
-        $installCmd += "-Annotation '$Annotation'"
-      }
-      if (![string]::IsNullOrEmpty($Name)) {
-        $installCmd += "-Name $Name"
-      }
-      if ($script:NormalizedIdDetectors.Count -gt 0) {
-        # Values were validated against $script:ValidIdDetectors (alphanumerics
-        # and dashes only) so they're safe to splice in. Use the normalized,
-        # joined form to avoid re-using the raw -IdDetector input.
-        $joined = $script:NormalizedIdDetectors -join ','
-        $installCmd += "-IdDetector `"$joined`""
-      }
-      if (![string]::IsNullOrEmpty($Proxy)) {
-        $installCmd += "-Proxy $Proxy"
-      }
-      if ($UpdateTask.ToLower() -eq 'enable') {
-        $installCmd += "-UpdateTask enable -Time $Time -Interval $Interval;"
-      }
-
-      $command += ($installCmd -join ' ')
-
-      # Wrap command in quotes for -Command argument
-      $taskArgument = "-NoProfile -WindowStyle Hidden -ExecutionPolicy RemoteSigned -Command `"&{ $($command -join ' ') }`""
+      $taskArgument = Get-MondooUpdaterTaskArgument @taskArgs
       info " * Scheduled Task argument: $taskArgument"
 
       # Build scheduled task components
@@ -739,6 +710,78 @@ $detectorYaml
     # reset erroractionpreference
     $erroractionpreference = $previous_erroractionpreference
   }
+}
+
+function Get-MondooUpdaterTaskArgument {
+  # Build the powershell.exe argument string for the Mondoo updater scheduled task.
+  #
+  # This is intentionally a pure, string-only function (no side effects, no Windows-only
+  # cmdlets) so the quoting can be unit-tested off-Windows. See test/install.Tests.ps1.
+  #
+  # IMPORTANT: the whole payload is wrapped in -Command "...". Every value spliced into
+  # that payload MUST use single quotes (or no quotes) and never an embedded double quote.
+  # An unescaped double quote inside the payload terminates the outer -Command string when
+  # powershell.exe parses the task argument, truncating the &{ ... } block and silently
+  # breaking the updater. A double-quoted -IdDetector did exactly that.
+  [CmdletBinding()]
+  [OutputType([string])]
+  param(
+    [string]   $Product = 'mondoo',
+    [string]   $Path = 'C:\Program Files\Mondoo\',
+    [string]   $Service = '',
+    [string]   $Annotation = '',
+    [string]   $Name = '',
+    [string[]] $IdDetector = @(),
+    [string]   $Proxy = '',
+    [string]   $UpdateTask = '',
+    [string]   $Time = '',
+    [string]   $Interval = ''
+  )
+
+  # Start building the command string
+  $command = @(
+    '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;'
+    '$wc = New-Object Net.Webclient;'
+  )
+
+  if (![string]::IsNullOrEmpty($Proxy)) {
+    $command += '$wc.proxy = New-Object System.Net.WebProxy(' + "'$Proxy'" + ');'
+  }
+
+  $command += 'iex ($wc.DownloadString(' + "'https://install.mondoo.com/ps1'" + '));'
+
+  # Start building the Install-Mondoo command. Quote spliced values with single quotes only.
+  $installCmd = @('Install-Mondoo')
+  $installCmd += "-Product $Product"
+  $installCmd += "-Path '$Path'"
+
+  if ($Service.ToLower() -eq 'enable' -and $Product.ToLower() -eq 'mondoo') {
+    $installCmd += '-Service enable'
+  }
+  if (![string]::IsNullOrEmpty($Annotation)) {
+    $installCmd += "-Annotation '$Annotation'"
+  }
+  if (![string]::IsNullOrEmpty($Name)) {
+    $installCmd += "-Name $Name"
+  }
+  if ($IdDetector.Count -gt 0) {
+    # Single quotes, NOT double — a double quote here terminates the outer -Command
+    # string and breaks the whole task (the original bug). Values are validated against
+    # an allowlist (alphanumerics/dashes) upstream, so single quotes are safe.
+    $joined = $IdDetector -join ','
+    $installCmd += "-IdDetector '$joined'"
+  }
+  if (![string]::IsNullOrEmpty($Proxy)) {
+    $installCmd += "-Proxy $Proxy"
+  }
+  if ($UpdateTask.ToLower() -eq 'enable') {
+    $installCmd += "-UpdateTask enable -Time $Time -Interval $Interval;"
+  }
+
+  $command += ($installCmd -join ' ')
+
+  # Wrap command in quotes for -Command argument
+  "-NoProfile -WindowStyle Hidden -ExecutionPolicy RemoteSigned -Command `"&{ $($command -join ' ') }`""
 }
 
 # SIG # Begin signature block

--- a/test/install.Tests.ps1
+++ b/test/install.Tests.ps1
@@ -1,0 +1,89 @@
+# Copyright Mondoo, Inc. 2025, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Pester v5 tests for install.ps1.
+#
+# Focus: the Mondoo updater scheduled-task argument builder. The whole command is
+# wrapped in `powershell.exe ... -Command "&{ ... }"`, so any value spliced into the
+# payload must use single quotes (or none). A single unescaped double quote inside the
+# payload terminates the outer -Command string when the scheduled task is parsed,
+# truncating the &{ ... } block and silently breaking the updater. That is exactly what
+# a double-quoted -IdDetector value did, so these tests guard the whole class of bug.
+
+BeforeAll {
+    $installPs1 = (Resolve-Path (Join-Path $PSScriptRoot '..' 'install.ps1')).Path
+    $src = Get-Content -Raw -LiteralPath $installPs1
+
+    # install.ps1 has '#Requires -RunAsAdministrator', so it cannot be dot-sourced on a
+    # CI runner. Instead, locate the builder via the AST and define only that function.
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput($src, [ref]$null, [ref]$null)
+    $fnAst = $ast.Find(
+        {
+            param($node)
+            ($node -is [System.Management.Automation.Language.FunctionDefinitionAst]) -and
+            ($node.Name -eq 'Get-MondooUpdaterTaskArgument')
+        }, $true)
+
+    if (-not $fnAst) {
+        throw "Get-MondooUpdaterTaskArgument was not found in install.ps1. The updater-task " +
+        "argument must be built by a standalone, testable function so its quoting stays covered."
+    }
+
+    . ([scriptblock]::Create($fnAst.Extent.Text))
+}
+
+Describe 'Get-MondooUpdaterTaskArgument' {
+
+    It 'wraps the -Command payload in exactly one pair of double quotes when -IdDetector is set' {
+        $arg = Get-MondooUpdaterTaskArgument -Product 'mondoo' -Path 'C:\Program Files\Mondoo\' `
+            -Service 'enable' -IdDetector @('windows-ad-sid', 'hostname') `
+            -UpdateTask 'enable' -Time '12:00' -Interval '3'
+
+        # The only double quotes in the whole argument are the pair that wraps -Command "...".
+        # The original bug double-quoted the -IdDetector value, adding interior quotes that
+        # truncated the -Command string and broke the task.
+        ($arg.ToCharArray() | Where-Object { $_ -eq '"' }).Count |
+            Should -Be 2 -Because 'a double quote inside the -Command payload silently breaks the scheduled task'
+
+        $arg | Should -Match "-IdDetector 'windows-ad-sid,hostname'"
+        $arg | Should -Not -Match '-IdDetector "'
+    }
+
+    It 'produces a -Command payload that parses as valid PowerShell' {
+        $arg = Get-MondooUpdaterTaskArgument -Product 'mondoo' -Path 'C:\Program Files\Mondoo\' `
+            -Service 'enable' -IdDetector @('windows-ad-sid', 'hostname') `
+            -UpdateTask 'enable' -Time '12:00' -Interval '3'
+
+        ($arg -match '-Command "(.*)"\s*$') | Should -BeTrue
+        $payload = $Matches[1]
+
+        $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseInput($payload, [ref]$null, [ref]$errors) | Out-Null
+        $errors | Should -BeNullOrEmpty -Because "the task's -Command payload must be valid PowerShell: $payload"
+    }
+
+    It 'never emits interior double quotes for any combination of spliced parameters' {
+        $cases = @(
+            @{ IdDetector = @('windows-ad-sid', 'hostname'); Annotation = 'env=prod,role=db'; Name = 'host-01'; Proxy = 'http://proxy.local:3128' }
+            @{ IdDetector = @('hostname'); Annotation = ''; Name = ''; Proxy = '' }
+            @{ IdDetector = @(); Annotation = 'team=sec'; Name = 'host-02'; Proxy = '' }
+            @{ IdDetector = @('machine-id', 'hostname'); Annotation = ''; Name = ''; Proxy = '' }
+        )
+        foreach ($c in $cases) {
+            $arg = Get-MondooUpdaterTaskArgument -Product 'mondoo' -Path 'C:\Program Files\Mondoo\' `
+                -Service 'enable' -IdDetector $c.IdDetector -Annotation $c.Annotation -Name $c.Name `
+                -Proxy $c.Proxy -UpdateTask 'enable' -Time '12:00' -Interval '3'
+
+            ($arg.ToCharArray() | Where-Object { $_ -eq '"' }).Count |
+                Should -Be 2 -Because "interior double quotes break the task (case: $($c | ConvertTo-Json -Compress))"
+        }
+    }
+
+    It 'omits -IdDetector entirely when no detectors are supplied' {
+        $arg = Get-MondooUpdaterTaskArgument -Product 'mondoo' -Path 'C:\Program Files\Mondoo\' `
+            -Service 'enable' -UpdateTask 'enable' -Time '12:00' -Interval '3'
+
+        $arg | Should -Not -Match '-IdDetector'
+        ($arg.ToCharArray() | Where-Object { $_ -eq '"' }).Count | Should -Be 2
+    }
+}


### PR DESCRIPTION
## Problem

The Mondoo updater scheduled task wraps its whole payload in
`powershell.exe ... -Command "&{ ... }"`. `-IdDetector` was the **only**
parameter spliced into that payload with **double** quotes
(`-IdDetector "a,b"`) — every other value uses single quotes or none.

Those inner double quotes collided with the outer `-Command "..."`: when
`powershell.exe` parses the task argument, the `-Command` string terminates at
the first inner quote, truncating the `&{ ... }` block so the `Install-Mondoo`
call never runs.

**Impact:** any host installed with `-IdDetector` got a broken `MondooUpdater`
task. It never upgraded or restarted the agent, so a stopped agent could not
self-heal. Introduced in #717.

## Fix

Single-quote the `-IdDetector` value, matching every other parameter. The
values are already validated against an allowlist (alphanumerics/dashes), so
single quotes are safe and can't collide with the outer `-Command` string.

## Test

To make the (fragile) task-argument quoting testable off-Windows, the builder
is extracted into a pure `Get-MondooUpdaterTaskArgument` function. A new Pester
test (`test/install.Tests.ps1`) asserts the `-Command` payload carries exactly
one pair of double quotes (no interior quotes) for every combination of spliced
parameters — which fails on the old double-quoted `-IdDetector`, and generalizes
to any future parameter that's wrongly double-quoted. A new workflow
(`.github/workflows/test_powershell_pester.yml`) runs it on PRs touching
`install.ps1`.

## Notes

- This source fix protects new installs/redeploys. Already-deployed broken
  tasks need a separate in-place remediation (swap the `-IdDetector` double
  quotes for single quotes in the existing task `Arguments`, then trigger it).
- `Mondoo.Installer.psm1` does not pass `-IdDetector` into its updater task, so
  it has no equivalent bug (could get the same hardening as a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
