### PR TITLE
Trust mondoohq/mondoo tap in Homebrew release tests

### DIFF
--- a/.github/workflows/test-released-brew.yaml
+++ b/.github/workflows/test-released-brew.yaml
@@ -34,6 +34,7 @@ jobs:
       - name: Testing install of ${{ matrix.package }}....
         run: |
           brew tap mondoohq/mondoo
+          brew trust mondoohq/mondoo
           brew install ${{ matrix.package }}
 
       - name: Version
@@ -61,6 +62,8 @@ jobs:
 
       - name: Testing install of mondoo cask....
         run: |
+          brew tap mondoohq/mondoo
+          brew trust mondoohq/mondoo
           brew install --cask mondoohq/mondoo/mondoo
 
       - name: Version

--- a/.github/workflows/test-released-brew.yaml
+++ b/.github/workflows/test-released-brew.yaml
@@ -34,6 +34,7 @@ jobs:
       - name: Testing install of ${{ matrix.package }}....
         run: |
           brew tap mondoohq/mondoo
+          # brew trust is required for non-official taps: https://docs.brew.sh/Tap-Trust
           brew trust mondoohq/mondoo
           brew install ${{ matrix.package }}
 
@@ -63,6 +64,7 @@ jobs:
       - name: Testing install of mondoo cask....
         run: |
           brew tap mondoohq/mondoo
+          # brew trust is required for non-official taps: https://docs.brew.sh/Tap-Trust
           brew trust mondoohq/mondoo
           brew install --cask mondoohq/mondoo/mondoo
 


### PR DESCRIPTION
## Summary
- Homebrew's new [Tap Trust](https://docs.brew.sh/Tap-Trust) feature refuses to load formulae from non-official taps unless they are explicitly trusted. The macOS runner picked up a Homebrew version that enforces this, breaking the `formulae` legs of the release brew tests with `Refusing to load formula mondoohq/mondoo/cnspec from untrusted tap mondoohq/mondoo`.
- Add `brew trust mondoohq/mondoo` after tapping in the `formulae` job so `mql`/`cnspec` install again.
- Add the same tap + trust to the `cask` job to future-proof it (it currently passes via a fully-qualified install, but trust avoids it breaking the same way).

## Test plan
- [ ] Trigger the released Homebrew test workflow (`workflow_dispatch` or next release run) and confirm `formulae (mql)`, `formulae (cnspec)`, and `cask` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)