### PR TITLE
Fix cnspec.service crash loop when user-context config exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -587,6 +587,8 @@ configure_token() {
         if [ ! -f /etc/opt/mondoo/mondoo.yml ] && [ -f "$config_path/mondoo.yml" ]; then
           sudo_cmd mkdir -p /etc/opt/mondoo
           sudo_cmd cp "$config_path/mondoo.yml" /etc/opt/mondoo/mondoo.yml
+          # mondoo.yml contains the service account credential; restrict access.
+          sudo_cmd chmod 0600 /etc/opt/mondoo/mondoo.yml
         fi
       fi
     fi

--- a/install.sh
+++ b/install.sh
@@ -579,17 +579,10 @@ configure_token() {
     if [ "$MONDOO_SERVICE" = "enable" ]; then
       if [ "$OS" = "macOS" ]; then
         sudo_cmd cp "$config_path/mondoo.yml" /Library/Mondoo/etc/mondoo.yml
-      else
-        # cnspec status (above) may have been satisfied by a user-context config
-        # at $HOME/.config/mondoo/mondoo.yml. The systemd service reads from
-        # /etc/opt/mondoo/mondoo.yml — if it's missing, seed it from the user
-        # config so the service doesn't crash-loop on start.
-        if [ ! -f /etc/opt/mondoo/mondoo.yml ] && [ -f "$config_path/mondoo.yml" ]; then
-          sudo_cmd mkdir -p /etc/opt/mondoo
-          sudo_cmd cp "$config_path/mondoo.yml" /etc/opt/mondoo/mondoo.yml
-          # mondoo.yml contains the service account credential; restrict access.
-          sudo_cmd chmod 0600 /etc/opt/mondoo/mondoo.yml
-        fi
+      elif [ ! -f /etc/opt/mondoo/mondoo.yml ] && [ -f "$config_path/mondoo.yml" ]; then
+        sudo_cmd mkdir -p /etc/opt/mondoo
+        sudo_cmd cp "$config_path/mondoo.yml" /etc/opt/mondoo/mondoo.yml
+        sudo_cmd chmod 0600 /etc/opt/mondoo/mondoo.yml
       fi
     fi
     return

--- a/install.sh
+++ b/install.sh
@@ -576,8 +576,19 @@ configure_token() {
     purple_bold "(you can manually run '${MONDOO_BINARY} login' to re-authenticate)."
     purple_bold "To re-register with a new space, please remove your Mondoo config file first."
     config_path="$HOME/.config/mondoo"
-    if [ "$MONDOO_SERVICE" = "enable" ] && [ "$OS" = "macOS" ]; then
-      sudo_cmd cp "$config_path/mondoo.yml" /Library/Mondoo/etc/mondoo.yml
+    if [ "$MONDOO_SERVICE" = "enable" ]; then
+      if [ "$OS" = "macOS" ]; then
+        sudo_cmd cp "$config_path/mondoo.yml" /Library/Mondoo/etc/mondoo.yml
+      else
+        # cnspec status (above) may have been satisfied by a user-context config
+        # at $HOME/.config/mondoo/mondoo.yml. The systemd service reads from
+        # /etc/opt/mondoo/mondoo.yml — if it's missing, seed it from the user
+        # config so the service doesn't crash-loop on start.
+        if [ ! -f /etc/opt/mondoo/mondoo.yml ] && [ -f "$config_path/mondoo.yml" ]; then
+          sudo_cmd mkdir -p /etc/opt/mondoo
+          sudo_cmd cp "$config_path/mondoo.yml" /etc/opt/mondoo/mondoo.yml
+        fi
+      fi
     fi
     return
   fi


### PR DESCRIPTION
## Summary
- In `configure_token()`, when `cnspec status` reports the host as already registered via a user-context config (`\$HOME/.config/mondoo/mondoo.yml`), the early-return branch only copied the config to the service path on macOS. On Linux/systemd, `cnspec.service` was then enabled and started against a missing `/etc/opt/mondoo/mondoo.yml`, causing a crash loop.
- Mirror the macOS behavior on Linux: when `MONDOO_SERVICE=enable` and `/etc/opt/mondoo/mondoo.yml` is missing, seed it from the user-context config so the service starts cleanly.
- Guard the copy on the system-wide config being absent so we never overwrite an existing service config.

Fixes #735

## Test plan
- [ ] Reproduce the issue per the steps in #735 against a clean Linux container (e.g. `oraclelinux:9` / `almalinux:9`):
  - As root, `cnspec login --token <TOKEN>` (no `--config`) → writes `/root/.config/mondoo/mondoo.yml`.
  - Run `curl -sSL https://install.mondoo.com/sh | bash -s -- -u enable -s enable -t \$MONDOO_REGISTRATION_TOKEN`.
- [ ] With this patch applied, confirm `/etc/opt/mondoo/mondoo.yml` is created and `cnspec.service` reaches `active (running)` without restarts.
- [ ] Confirm the non-skip path still works (no pre-existing user config) — `configure_linux_token` still writes the service config directly.
- [ ] Confirm we do not overwrite an existing `/etc/opt/mondoo/mondoo.yml` when both configs are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)