### PR TITLE
Trust mondoohq/mondoo tap in macOS install.sh release tests

### DIFF
--- a/.github/workflows/test-released-install-sh.yaml
+++ b/.github/workflows/test-released-install-sh.yaml
@@ -166,6 +166,9 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Install.sh/${{ matrix.package }} on ${{ matrix.os }}
         run: |
+          brew tap mondoohq/mondoo
+          # brew trust is required for non-official taps: https://docs.brew.sh/Tap-Trust
+          brew trust mondoohq/mondoo
           bash -c "$(curl -sSL https://install.mondoo.com/sh/${{ matrix.package }})"
           ${{ matrix.package }} version
       - name: Verify the correct version is installed


### PR DESCRIPTION
## Summary
- The macOS legs of the release `install.sh` tests failed in [run 29768756108](https://github.com/mondoohq/installer/actions/runs/29768756108/attempts/1) with `Refusing to load formula mondoohq/mondoo/cnspec from untrusted tap mondoohq/mondoo`.
- Homebrew's new [Tap Trust](https://docs.brew.sh/Tap-Trust) feature refuses to load formulae from non-official taps unless they are explicitly trusted. Tap and `brew trust mondoohq/mondoo` in the `install-sh-macos` job before running the install script — the same fix #729 applied to the Homebrew release tests.

## Test plan
- [ ] Re-run the release test workflow and confirm `install-sh-macos (cnspec)` and `install-sh-macos (mql)` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)