### PR TITLE
Install brew formula by fully qualified name for Tap Trust

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -328,12 +328,19 @@ configure_macos_installer() {
     # Homebrew doesn't support empty metapackages, so we redefine the package name to cnspec
     MONDOO_PKG_NAME="cnspec"
 
+    # Since Homebrew 6.0.0, formulae from non-official taps must be trusted before
+    # they can be loaded. Installing (or upgrading) by fully qualified name trusts
+    # just that formula, so users don't have to trust the whole tap or run
+    # 'brew trust' themselves. See: https://docs.brew.sh/Tap-Trust
+    MONDOO_BREW_TAP="mondoohq/mondoo"
+    MONDOO_BREW_FORMULA="${MONDOO_BREW_TAP}/${MONDOO_PKG_NAME}"
+
     mondoo_install() {
       purple_bold "\n* Configuring brew sources for Mondoo Repository via 'brew tap'"
-      brew tap mondoohq/mondoo
+      brew tap ${MONDOO_BREW_TAP}
 
       purple_bold "\n* Installing ${MONDOO_PRODUCT_NAME} via 'brew install'"
-      brew install ${MONDOO_PKG_NAME} -q
+      brew install ${MONDOO_BREW_FORMULA} -q
     }
 
     mondoo_update() {
@@ -341,9 +348,9 @@ configure_macos_installer() {
       if brew tap | grep mondoolabs/mondoo >/dev/null; then
         purple_bold "  - Legacy tap already exists, uninstalling Mondoo and re-installing from new tap"
         brew uninstall ${MONDOO_PKG_NAME} && brew untap mondoolabs/mondoo
-        brew tap mondoohq/mondoo && brew install ${MONDOO_PKG_NAME}
+        brew tap ${MONDOO_BREW_TAP} && brew install ${MONDOO_BREW_FORMULA}
       else
-        brew upgrade ${MONDOO_PKG_NAME} -q
+        brew upgrade ${MONDOO_BREW_FORMULA} -q
       fi
     }
 

--- a/install.sh
+++ b/install.sh
@@ -337,20 +337,20 @@ configure_macos_installer() {
 
     mondoo_install() {
       purple_bold "\n* Configuring brew sources for Mondoo Repository via 'brew tap'"
-      brew tap ${MONDOO_BREW_TAP}
+      brew tap "${MONDOO_BREW_TAP}"
 
       purple_bold "\n* Installing ${MONDOO_PRODUCT_NAME} via 'brew install'"
-      brew install ${MONDOO_BREW_FORMULA} -q
+      brew install "${MONDOO_BREW_FORMULA}" -q
     }
 
     mondoo_update() {
       purple_bold "\n* Upgrade ${MONDOO_PRODUCT_NAME} via 'brew upgrade'"
       if brew tap | grep mondoolabs/mondoo >/dev/null; then
         purple_bold "  - Legacy tap already exists, uninstalling Mondoo and re-installing from new tap"
-        brew uninstall ${MONDOO_PKG_NAME} && brew untap mondoolabs/mondoo
-        brew tap ${MONDOO_BREW_TAP} && brew install ${MONDOO_BREW_FORMULA}
+        brew uninstall "${MONDOO_PKG_NAME}" && brew untap mondoolabs/mondoo
+        brew tap "${MONDOO_BREW_TAP}" && brew install "${MONDOO_BREW_FORMULA}"
       else
-        brew upgrade ${MONDOO_BREW_FORMULA} -q
+        brew upgrade "${MONDOO_BREW_FORMULA}" -q
       fi
     }
 


### PR DESCRIPTION
Since Homebrew 6.0.0, formulae from non-official taps are not loaded
unless they are trusted, so `brew install cnspec` fails with "Refusing to
load formula mondoohq/mondoo/cnspec from untrusted tap" on a fresh macOS
install. #738 worked around this in the release tests by running
`brew trust mondoohq/mondoo` before install.sh, but users running the
script directly still hit the failure.

Install and upgrade by fully qualified name (mondoohq/mondoo/cnspec)
instead. Homebrew trusts just that formula when it is named in full
(cmd/install.rb and cmd/upgrade.rb both call trust_fully_qualified_items!),
so no `brew trust` call is needed and we don't ask users to trust every
current and future item in the tap. See https://docs.brew.sh/Tap-Trust

The tap and formula are held in MONDOO_BREW_TAP / MONDOO_BREW_FORMULA so
the qualified name follows MONDOO_PKG_NAME for the per-product variants of
this script. `brew uninstall` in the legacy mondoolabs migration path stays
unqualified: it operates on the installed keg from the old tap.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
