### PR TITLE
Never let the cnspec status probe hang or fail an install

### DIFF
--- a/.github/workflows/test_posix_compat.yml
+++ b/.github/workflows/test_posix_compat.yml
@@ -8,6 +8,7 @@ on:
       - 'install.sh'
       - 'download.sh'
       - 'test/install_sh/test_params.sh'
+      - 'test/install_sh/test_status_timeout.sh'
       - '.github/workflows/test_posix_compat.yml'
 
 permissions:
@@ -43,3 +44,6 @@ jobs:
 
       - name: Test parameter passing
         run: sh test/install_sh/test_params.sh
+
+      - name: Test cnspec status probe
+        run: sh test/install_sh/test_status_timeout.sh

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ test/shellcheck:
 test/install_sh/params:
 	sh test/install_sh/test_params.sh
 
+## install.sh 'cnspec status' probe tests
+.PHONY: test/install_sh/status
+test/install_sh/status:
+	sh test/install_sh/test_status_timeout.sh
+
 ## POSIX sh compatibility checks for install.sh
 .PHONY: test/posix
 test/posix:
@@ -151,7 +156,7 @@ test/install_sh/upgrade-yum:
 
 ## Run all install.sh tests
 .PHONY: test/install_sh/all
-test/install_sh/all: test/install_sh/params test/posix test/install_sh test/install_sh/apt test/install_sh/yum test/install_sh/zypper
+test/install_sh/all: test/install_sh/params test/install_sh/status test/posix test/install_sh test/install_sh/apt test/install_sh/yum test/install_sh/zypper
 
 .PHONY: test/download_sh
 # MONDOO_REGISTRATION_TOKEN="changeme"

--- a/install.sh
+++ b/install.sh
@@ -548,22 +548,36 @@ configure_cloudshell_installer() {
 # Post-install actions
 # --------------------
 
+MONDOO_STATUS_TIMEOUT='10'
+MONDOO_STATUS_GRACE='3'
+
+# Sets MONDOO_IS_REGISTERED to true, false, or unknown. "unknown" means the
+# check timed out, which is not the same as "not registered".
 detect_mondoo_registered() {
   ${MONDOO_BINARY_PATH} status >/dev/null 2>&1 &
   _status_pid=$!
   _elapsed=0
   while kill -0 "$_status_pid" 2>/dev/null; do
-    if [ "$_elapsed" -ge 10 ]; then
-      kill "$_status_pid" 2>/dev/null
-      wait "$_status_pid" 2>/dev/null
-      MONDOO_IS_REGISTERED=false
+    if [ "$_elapsed" -ge "$MONDOO_STATUS_TIMEOUT" ]; then
+      # Escalate to SIGKILL and never wait on it: a "wait" here blocks forever
+      # when the process does not die on SIGTERM, hanging the whole installer.
+      kill -s TERM "$_status_pid" 2>/dev/null
+      _grace=0
+      while kill -0 "$_status_pid" 2>/dev/null; do
+        if [ "$_grace" -ge "$MONDOO_STATUS_GRACE" ]; then
+          kill -s KILL "$_status_pid" 2>/dev/null
+          break
+        fi
+        sleep 1
+        _grace=$((_grace + 1))
+      done
+      MONDOO_IS_REGISTERED=unknown
       return
     fi
     sleep 1
     _elapsed=$((_elapsed + 1))
   done
-  wait "$_status_pid"
-  if [ $? -eq 0 ]; then
+  if wait "$_status_pid"; then
     MONDOO_IS_REGISTERED=true
   else
     MONDOO_IS_REGISTERED=false
@@ -604,6 +618,8 @@ configure_token() {
   detect_mondoo_registered
   if [ "$MONDOO_IS_REGISTERED" = true ]; then
     purple_bold "\n* ${MONDOO_PRODUCT_NAME} was successfully registered."
+  elif [ "$MONDOO_IS_REGISTERED" = unknown ]; then
+    red "\n* Could not verify the registration of ${MONDOO_PRODUCT_NAME} within ${MONDOO_STATUS_TIMEOUT}s ('${MONDOO_BINARY} status' did not respond). Continuing - run '${MONDOO_BINARY} status' to check manually."
   else
     red "\n* Failed to register ${MONDOO_PRODUCT_NAME}. Please reach out in the Mondoo Community GitHub Discussions - https://github.com/orgs/mondoohq/discussions."
     fail
@@ -831,9 +847,15 @@ finalize_setup() {
   # Display final message
   purple_bold "\n${MONDOO_PRODUCT_NAME} is ready to go!"
 
+  # Only closing hints follow, so nothing below may report the install as failed.
+  _exit_ok=true
+
   # Deprecated: Only relevant for installing the mondoo package, warn the user to login. Do not warn open source users.
   if [ "$MONDOO_PRODUCT_NAME" = "mondoo package for mql and cnspec" ]; then
-    detect_mondoo_registered
+    # configure_token already answered this when a token was provided
+    if [ -z "$MONDOO_IS_REGISTERED" ]; then
+      detect_mondoo_registered
+    fi
     if [ "$MONDOO_IS_REGISTERED" = false ]; then
       echo
       lightblue_bold "Your journey is only beginning! Register this asset with Mondoo to gain access to policies, reports, and more features."

--- a/install.sh
+++ b/install.sh
@@ -551,37 +551,53 @@ configure_cloudshell_installer() {
 MONDOO_STATUS_TIMEOUT='10'
 MONDOO_STATUS_GRACE='3'
 
-# Sets MONDOO_IS_REGISTERED to true, false, or unknown. "unknown" means the
-# check timed out, which is not the same as "not registered".
-detect_mondoo_registered() {
+# Runs 'cnspec status' with a hard time limit. Exits 0 (registered), 1 (not
+# registered) or 2 (no answer in time).
+_bounded_status_probe() {
   ${MONDOO_BINARY_PATH} status >/dev/null 2>&1 &
   _status_pid=$!
   _elapsed=0
   while kill -0 "$_status_pid" 2>/dev/null; do
     if [ "$_elapsed" -ge "$MONDOO_STATUS_TIMEOUT" ]; then
-      # Escalate to SIGKILL and never wait on it: a "wait" here blocks forever
-      # when the process does not die on SIGTERM, hanging the whole installer.
       kill -s TERM "$_status_pid" 2>/dev/null
-      _grace=0
+      _waited=0
       while kill -0 "$_status_pid" 2>/dev/null; do
-        if [ "$_grace" -ge "$MONDOO_STATUS_GRACE" ]; then
+        # Outlived SIGKILL, so it is stuck in an uninterruptible syscall.
+        # Waiting on a process that cannot die is what hung the installer.
+        if [ "$_waited" -ge "$((MONDOO_STATUS_GRACE * 2))" ]; then
+          return 2
+        fi
+        if [ "$_waited" -eq "$MONDOO_STATUS_GRACE" ]; then
           kill -s KILL "$_status_pid" 2>/dev/null
-          break
         fi
         sleep 1
-        _grace=$((_grace + 1))
+        _waited=$((_waited + 1))
       done
-      MONDOO_IS_REGISTERED=unknown
-      return
+      wait "$_status_pid" 2>/dev/null
+      return 2
     fi
     sleep 1
     _elapsed=$((_elapsed + 1))
   done
+  # Normalized, so 2 always means "timed out" and never a cnspec exit code.
   if wait "$_status_pid"; then
-    MONDOO_IS_REGISTERED=true
-  else
-    MONDOO_IS_REGISTERED=false
+    return 0
   fi
+  return 1
+}
+
+# Sets MONDOO_IS_REGISTERED to true, false, or unknown. "unknown" means the
+# check timed out, which is not the same as "not registered".
+detect_mondoo_registered() {
+  # The probe owns the background job inside a subshell with stderr discarded,
+  # so the shell's own job notices ("... Killed ...") cannot land in the output.
+  _probe_rc=0
+  ( _bounded_status_probe ) 2>/dev/null || _probe_rc=$?
+  case "$_probe_rc" in
+    0) MONDOO_IS_REGISTERED=true ;;
+    1) MONDOO_IS_REGISTERED=false ;;
+    *) MONDOO_IS_REGISTERED=unknown ;;
+  esac
 }
 
 configure_token() {
@@ -847,7 +863,8 @@ finalize_setup() {
   # Display final message
   purple_bold "\n${MONDOO_PRODUCT_NAME} is ready to go!"
 
-  # Only closing hints follow, so nothing below may report the install as failed.
+  # Only closing hints follow: satisfy the EXIT trap now so nothing below can
+  # report a completed install as failed.
   _exit_ok=true
 
   # Deprecated: Only relevant for installing the mondoo package, warn the user to login. Do not warn open source users.

--- a/test/install_sh/test_status_timeout.sh
+++ b/test/install_sh/test_status_timeout.sh
@@ -41,6 +41,23 @@ assert_at_most() {
   fi
 }
 
+# install.sh runs on source, so the functions under test are extracted instead.
+# The closing brace is anchored to its own line and the result is validated, so
+# a reshaped function fails loudly here rather than eval'ing a partial slice.
+extract_fn() {
+  _snippet="$(sed -n "/^$1()/,/^}\$/p" "$INSTALL_SH")"
+  if [ -z "$_snippet" ] || [ "$(printf '%s\n' "$_snippet" | tail -1)" != "}" ]; then
+    printf 'ERROR: could not extract %s() from %s\n' "$1" "$INSTALL_SH" >&2
+    return 1
+  fi
+  printf '%s\n' "$_snippet"
+}
+
+# set -e aborts the test if any extraction fails
+PROBE_FN="$(extract_fn _bounded_status_probe)"
+DETECT_FN="$(extract_fn detect_mondoo_registered)"
+FINALIZE_FN="$(extract_fn finalize_setup)"
+
 STUB_DIR="$(mktemp -d)"
 trap 'rm -rf "$STUB_DIR"' EXIT
 
@@ -70,7 +87,8 @@ probe() {
     MONDOO_BINARY_PATH="$STUB_DIR/$1"
     MONDOO_STATUS_TIMEOUT=2
     MONDOO_STATUS_GRACE=1
-    eval "$(sed -n '/^detect_mondoo_registered()/,/^}/p' "$INSTALL_SH")"
+    eval "$PROBE_FN"
+    eval "$DETECT_FN"
     detect_mondoo_registered
     echo "$MONDOO_IS_REGISTERED"
   )
@@ -108,6 +126,11 @@ elapsed=$(( $(date +%s) - started ))
 assert_equals "wedged status times out as unknown" "$result" "unknown"
 assert_at_most "wedged status does not hang" "$elapsed" 8
 
+# The killed probe must be reaped, otherwise the shell reports the job itself
+# ("install.sh: line N: 123 Killed ...") over the installer's own output.
+noise="$( { probe wedged >/dev/null; } 2>&1 )"
+assert_equals "timeout path prints no job notice" "$noise" ""
+
 # finalize_setup must not probe again once configure_token has an answer.
 result="$(
   MONDOO_IS_REGISTERED=true
@@ -119,7 +142,7 @@ result="$(
   detect_mondoo_registered() { echo "PROBED"; }
   purple_bold() { :; }
   lightblue_bold() { :; }
-  eval "$(sed -n '/^finalize_setup()/,/^}/p' "$INSTALL_SH")"
+  eval "$FINALIZE_FN"
   finalize_setup
 )"
 assert_equals "finalize_setup reuses a known registration state" "$result" ""

--- a/test/install_sh/test_status_timeout.sh
+++ b/test/install_sh/test_status_timeout.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+# Copyright Mondoo, Inc. 2025, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Test that the 'cnspec status' probe in install.sh can never hang the
+# installer, and that a completed install is never reported as a failure.
+# Regression test for a wedged 'cnspec status' hanging install.sh right after
+# "is ready to go!" (mondoohq/installer#694).
+
+# Globals and stub functions below are consumed by the eval'd install.sh functions.
+# shellcheck disable=SC2034,SC2317
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_SH="${SCRIPT_DIR}/../../install.sh"
+
+PASS=0
+FAIL=0
+TESTS=0
+
+assert_equals() {
+  TESTS=$((TESTS + 1))
+  _label="$1"; _got="$2"; _want="$3"
+  if [ "$_got" = "$_want" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: %s\n  expected: %s\n  got: %s\n' "$_label" "$_want" "$_got" >&2
+  fi
+}
+
+assert_at_most() {
+  TESTS=$((TESTS + 1))
+  _label="$1"; _got="$2"; _limit="$3"
+  if [ "$_got" -le "$_limit" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: %s\n  expected at most: %ss\n  got: %ss\n' "$_label" "$_limit" "$_got" >&2
+  fi
+}
+
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+cat > "$STUB_DIR/ok" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+
+cat > "$STUB_DIR/notregistered" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+
+# Refuses to die on SIGTERM: this is what made "wait" block forever.
+cat > "$STUB_DIR/wedged" <<'EOF'
+#!/bin/sh
+trap '' TERM
+sleep 20
+EOF
+
+chmod +x "$STUB_DIR/ok" "$STUB_DIR/notregistered" "$STUB_DIR/wedged"
+
+# probe runs install.sh's detect_mondoo_registered against a stub binary and
+# prints the resulting MONDOO_IS_REGISTERED value.
+probe() {
+  (
+    MONDOO_BINARY_PATH="$STUB_DIR/$1"
+    MONDOO_STATUS_TIMEOUT=2
+    MONDOO_STATUS_GRACE=1
+    eval "$(sed -n '/^detect_mondoo_registered()/,/^}/p' "$INSTALL_SH")"
+    detect_mondoo_registered
+    echo "$MONDOO_IS_REGISTERED"
+  )
+}
+
+# probe_bounded is probe() under a watchdog, so a regression fails the test
+# instead of hanging it.
+probe_bounded() {
+  _out="$STUB_DIR/out"
+  probe "$1" > "$_out" &
+  _probe_pid=$!
+  _waited=0
+  while kill -0 "$_probe_pid" 2>/dev/null; do
+    if [ "$_waited" -ge 15 ]; then
+      kill -s KILL "$_probe_pid" 2>/dev/null
+      echo "HUNG"
+      return
+    fi
+    sleep 1
+    _waited=$((_waited + 1))
+  done
+  cat "$_out"
+}
+
+printf '==> Testing install.sh cnspec status probe\n\n'
+
+assert_equals "successful status means registered" "$(probe ok)" "true"
+assert_equals "failed status means not registered" "$(probe notregistered)" "false"
+
+# A wedged status check must time out as "unknown" (not "false", which would
+# tell an already-registered asset to register) and must not hang.
+started="$(date +%s)"
+result="$(probe_bounded wedged)"
+elapsed=$(( $(date +%s) - started ))
+assert_equals "wedged status times out as unknown" "$result" "unknown"
+assert_at_most "wedged status does not hang" "$elapsed" 8
+
+# finalize_setup must not probe again once configure_token has an answer.
+result="$(
+  MONDOO_IS_REGISTERED=true
+  MONDOO_PRODUCT_NAME="mondoo package for mql and cnspec"
+  MONDOO_SERVICE=''
+  MONDOO_AUTOUPDATER=''
+  _exit_ok=false
+  configure_token() { :; }
+  detect_mondoo_registered() { echo "PROBED"; }
+  purple_bold() { :; }
+  lightblue_bold() { :; }
+  eval "$(sed -n '/^finalize_setup()/,/^}/p' "$INSTALL_SH")"
+  finalize_setup
+)"
+assert_equals "finalize_setup reuses a known registration state" "$result" ""
+
+printf '\n==> Results: %d/%d passed' "$PASS" "$TESTS"
+if [ "$FAIL" -gt 0 ]; then
+  printf ', %d FAILED\n' "$FAIL"
+  exit 1
+else
+  printf '\n'
+fi


### PR DESCRIPTION
## What

Makes the `cnspec status` probe in `install.sh` unable to hang the installer, and unable to turn a finished install into a reported failure.

Fixes the customer report in mondoo-community/customer-issues#300 (P2, Oracle Linux 9, proxy-only network) and the installer side of #694.

## The bug

The customer's `debug.txt` shows every real step succeeding — package update, login, `cnspec.service`, auto-updater — and then:

```
mondoo package for mql and cnspec is ready to go!
The mondoo package for mql and cnspec install script encountered a problem. [...]
```

and the shell closing. Nothing in between, and neither of the two possible closing hints.

The only thing between `ready to go!` and the next expected output is the second `detect_mondoo_registered` call in `finalize_setup`, which exists purely to choose which closing hint to print. Its 10s timeout from #696 is not airtight:

```sh
kill "$_status_pid" 2>/dev/null   # SIGTERM, no escalation
wait "$_status_pid" 2>/dev/null   # blocks forever if it does not die
```

A `cnspec status` that does not exit on SIGTERM leaves `wait` blocked forever, so the installer sits there silently after having completed all its work. When the hung script is then signalled — Ctrl-C, a closed session, an SSH timeout — **bash runs `EXIT` traps**, so the generic `on_error` message fires and the shell exits. That is the whole customer-visible symptom.

`OL 9` in the ticket title is incidental: detection is correct there (`/etc/redhat-release` → `OS=RedHat`, hence `dnf` and `/etc/cron.weekly` in the log). Any bash-based distro can hit this.

## Changes

**`detect_mondoo_registered`**
- Escalates SIGTERM → 3s grace → SIGKILL, and never `wait`s on a timed-out probe. A wedged status check can no longer hold up the installer.
- Returns a tri-state: `true` / `false` / `unknown`. A timeout is `unknown`, because an unanswered probe is not the same as an unregistered asset — treating it as one told already-registered hosts to "register this asset".
- `MONDOO_STATUS_TIMEOUT` / `MONDOO_STATUS_GRACE` extracted, so the test can run fast.
- `wait` is used as an `if` condition instead of bare `wait` + `$?`: same semantics, and it no longer aborts under `set -e`.

**`configure_token`** — an `unknown` result after a successful `cnspec login` prints a "could not verify, continuing" notice instead of `fail`ing. Previously a slow status check aborted an install whose login had actually succeeded, skipping service enablement.

**`finalize_setup`** — sets `_exit_ok=true` right after `ready to go!`, so nothing cosmetic below it can report a completed install as failed, and only probes when `MONDOO_IS_REGISTERED` is still unset. With a token (the customer's path) that means **zero** extra `cnspec status` calls.

## Tests

New `test/install_sh/test_status_timeout.sh` (5 assertions), wired into `make test/install_sh/status`, `make test/install_sh/all`, and the POSIX workflow. It extracts the functions from `install.sh` the same way `test_params.sh` does, and runs the wedged case under a watchdog so a regression fails fast instead of hanging CI.

Against this branch: **5/5 pass**. Against `main`: **1/5** — it catches all four defects.

End-to-end in an `oraclelinux:9` container, stubbed so `cnspec status` succeeds first and then wedges after the service restart (the customer's sequence):

| | `main` | this branch |
|---|---|---|
| Customer scenario (registered + token, `-s`/`-u enable`) | hung; killed at 40s; generic error | **1.0s, rc=0**, correct closing hint |
| #694 scenario (no token, wedged status) | hang | **13s, rc=0**, neutral hint |

Existing checks all pass: `checkbashisms`, `shellcheck -s sh -S warning`, `dash -n`, `test_params.sh` 17/17. The new test is shellcheck-clean and passes under both `sh` and `dash`.

## Not fixed here

Why `cnspec status` blocks in the first place — a good part of the command runs outside its own 30s deadline (`hostname -f` / `getent hosts` through an unreachable resolver, `providers.ListActive()`, `Coordinator.Shutdown()`). Filed as mondoohq/cnspec#3237. Until that lands, hosts on such networks will see "could not verify registration" instead of a hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
