### PR TITLE
Declare System64Folder to fix the MSI link failure

### DIFF
--- a/packages/msi/msi/components.wxi
+++ b/packages/msi/msi/components.wxi
@@ -6,6 +6,10 @@
 
 <Include xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Directory Id="TARGETDIR" Name="SourceDir">
+      <!-- Referenced by the ConfigureMondooServiceRecovery custom action to
+           locate the native 64-bit sc.exe. WiX v3 requires standard
+           directories to be declared before they can be referenced. -->
+      <Directory Id="System64Folder" />
       <Directory Id="ProgramFiles64Folder">
         <Directory Id="INSTALLLOCATION" Name="Mondoo" />
       </Directory>


### PR DESCRIPTION
## What

Declares `System64Folder` in the MSI directory tree so the WiX linker can resolve it.

## Why

The v13.33.0 release failed: both [`Packaging: Windows MSI (amd64)`](https://github.com/mondoohq/installer/actions/runs/31527764353/job/93900384133) and [`Packaging: Windows MSI (arm64)`](https://github.com/mondoohq/installer/actions/runs/31527764353/job/93900384040) died in `light`:

```
packages\msi\msi\actions.wxi(18) : error LGHT0094 :
  Unresolved reference to symbol 'Directory:System64Folder' in section 'Product:*'.
```

(The `Move-Item ... mondoo_amd64.msi ... does not exist` error that follows is just fallout — `package.ps1` doesn't check `$LASTEXITCODE`, so it kept going after `light` had already failed.)

#745 added the `ConfigureMondooServiceRecovery` custom action with `Directory="System64Folder"`, but WiX v3 does not implicitly materialize standard directories — that's a WiX v4 `<StandardDirectory>` feature. The tree in `components.wxi` only had `TARGETDIR → ProgramFiles64Folder → INSTALLLOCATION`, so there was nothing for the linker to resolve against.

No `Name` attribute is needed on the new element: WiX v3 recognizes `System64Folder` as a standard directory ID and supplies the name itself, which is why the adjacent `ProgramFiles64Folder` omits it too.

## Why it wasn't caught

`pkg_msi.yaml` is `on: workflow_call:` only — there's no `pull_request` trigger, so the MSI is never compiled on PRs. #745's checks were CLA, GitGuardian, PSScriptAnalyzer, spellcheck, Shellcheck, and license-check; none of them run `candle`/`light`. The release was the first time this WiX authoring was ever compiled.

## Testing

Not verified by a build — WiX only exists on the Windows runner, and `pkg_msi.yaml` can't be triggered from a PR. **This needs a `workflow_dispatch` run of `pkg_published_trigger_build_release.yaml` with `skip-publish: true` before merge.** That also exercises the `Verify service recovery configuration and repair` step added in #745, which has never executed.

## Follow-ups (not in this PR)

- `package.ps1` should check `$LASTEXITCODE` after `candle`/`light` so WiX errors aren't masked by a downstream `Move-Item` failure.
- Consider a `pull_request` trigger that builds the MSI without signing/publishing, so WiX authoring changes are compiled before release.
- `ConfigureMondooServiceRecovery` is `Return="ignore"` and #745 removed the `<util:ServiceConfig>` fallback, so a silent failure leaves the service with no recovery policy at all. Worth confirming the action actually works once the build is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)