### PR TITLE
macOS: keep a single Mondoo config for service installs

### DIFF
--- a/.github/workflows/test_posix_compat.yml
+++ b/.github/workflows/test_posix_compat.yml
@@ -9,6 +9,7 @@ on:
       - 'download.sh'
       - 'test/install_sh/test_params.sh'
       - 'test/install_sh/test_status_timeout.sh'
+      - 'test/install_sh/test_macos_config.sh'
       - '.github/workflows/test_posix_compat.yml'
 
 permissions:
@@ -47,3 +48,6 @@ jobs:
 
       - name: Test cnspec status probe
         run: sh test/install_sh/test_status_timeout.sh
+
+      - name: Test macOS config handling
+        run: sh test/install_sh/test_macos_config.sh

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ test/install_sh/params:
 test/install_sh/status:
 	sh test/install_sh/test_status_timeout.sh
 
+## install.sh macOS config tests
+.PHONY: test/install_sh/macos_config
+test/install_sh/macos_config:
+	sh test/install_sh/test_macos_config.sh
+
 ## POSIX sh compatibility checks for install.sh
 .PHONY: test/posix
 test/posix:

--- a/install.sh
+++ b/install.sh
@@ -548,6 +548,10 @@ configure_cloudshell_installer() {
 # Post-install actions
 # --------------------
 
+# Config the launchd service reads. cnspec falls back to it when there is no
+# user config, so macOS service installs keep this one config only.
+MONDOO_MACOS_CONFIG='/Library/Mondoo/etc/mondoo.yml'
+
 MONDOO_STATUS_TIMEOUT='10'
 MONDOO_STATUS_GRACE='3'
 
@@ -612,11 +616,9 @@ configure_token() {
     purple_bold "\n* ${MONDOO_PRODUCT_NAME} is already logged-in. Skipping login"
     purple_bold "(you can manually run '${MONDOO_BINARY} login' to re-authenticate)."
     purple_bold "To re-register with a new space, please remove your Mondoo config file first."
-    config_path="$HOME/.config/mondoo"
-    if [ "$MONDOO_SERVICE" = "enable" ]; then
-      if [ "$OS" = "macOS" ]; then
-        sudo_cmd cp "$config_path/mondoo.yml" /Library/Mondoo/etc/mondoo.yml
-      elif [ ! -f /etc/opt/mondoo/mondoo.yml ] && [ -f "$config_path/mondoo.yml" ]; then
+    if [ "$MONDOO_SERVICE" = "enable" ] && [ "$OS" != "macOS" ]; then
+      config_path="$HOME/.config/mondoo"
+      if [ ! -f /etc/opt/mondoo/mondoo.yml ] && [ -f "$config_path/mondoo.yml" ]; then
         sudo_cmd mkdir -p /etc/opt/mondoo
         sudo_cmd cp "$config_path/mondoo.yml" /etc/opt/mondoo/mondoo.yml
         sudo_cmd chmod 0600 /etc/opt/mondoo/mondoo.yml
@@ -699,13 +701,39 @@ run_login_cmd() {
 
 configure_macos_token() {
   purple_bold "\n* Authenticate with Mondoo Platform"
-  config_path="$HOME/.config/mondoo"
-  mkdir -p "$config_path"
-
-  run_login_cmd "$config_path"
 
   if [ "$MONDOO_SERVICE" = "enable" ]; then
-    sudo_cmd cp "$config_path/mondoo.yml" /Library/Mondoo/etc/mondoo.yml
+    config_path="${MONDOO_MACOS_CONFIG%/*}"
+    sudo_cmd mkdir -p "$config_path"
+    run_login_cmd "$config_path"
+    # cnspec only falls back to the system config if it can read it
+    sudo_cmd chmod 0644 "$MONDOO_MACOS_CONFIG"
+  else
+    config_path="$HOME/.config/mondoo"
+    mkdir -p "$config_path"
+    run_login_cmd "$config_path"
+  fi
+}
+
+# Moves a user config from an older installer to the service config, so a
+# service install is not left with two configs that can drift apart.
+migrate_macos_config() {
+  _user_config="$HOME/.config/mondoo/mondoo.yml"
+  if [ ! -f "$_user_config" ]; then
+    return
+  fi
+
+  if [ ! -f "$MONDOO_MACOS_CONFIG" ]; then
+    purple_bold "\n* Moving ${_user_config} to ${MONDOO_MACOS_CONFIG}"
+    sudo_cmd mkdir -p "${MONDOO_MACOS_CONFIG%/*}"
+    sudo_cmd cp "$_user_config" "$MONDOO_MACOS_CONFIG"
+    sudo_cmd chmod 0644 "$MONDOO_MACOS_CONFIG"
+    sudo_cmd rm -f "$_user_config"
+  elif sudo_cmd cmp -s "$_user_config" "$MONDOO_MACOS_CONFIG"; then
+    purple_bold "\n* Removing the duplicate config at ${_user_config}"
+    sudo_cmd rm -f "$_user_config"
+  else
+    red "\n* ${_user_config} and ${MONDOO_MACOS_CONFIG} differ. The service uses ${MONDOO_MACOS_CONFIG}, remove ${_user_config} to avoid a split configuration."
   fi
 }
 
@@ -761,7 +789,7 @@ service() {
                 <string>/Library/Mondoo/bin/cnspec</string>
                 <string>serve</string>
                 <string>--config</string>
-                <string>/Library/Mondoo/etc/mondoo.yml</string>
+                <string>${MONDOO_MACOS_CONFIG}</string>
         </array>
         <key>RunAtLoad</key>
         <true/>
@@ -776,6 +804,7 @@ EOL
     sleep 5
     sudo_cmd launchctl bootstrap system /Library/LaunchDaemons/com.mondoo.client.plist
     sudo_cmd launchctl start com.mondoo.client
+    purple_bold "\n* The service and cnspec use the config at ${MONDOO_MACOS_CONFIG}"
   elif [ "$OS" = "Arch" ]; then
     purple_bold "\n* Enable and start the mondoo service"
     sudo_cmd systemctl enable mondoo.service
@@ -846,6 +875,10 @@ EOL
 }
 
 finalize_setup() {
+
+  if [ "$OS" = "macOS" ] && [ "$MONDOO_SERVICE" = "enable" ]; then
+    migrate_macos_config
+  fi
 
   # Authenticate with Mondoo platform if a registration token is provided
   configure_token

--- a/install.sh
+++ b/install.sh
@@ -706,13 +706,20 @@ configure_macos_token() {
     config_path="${MONDOO_MACOS_CONFIG%/*}"
     sudo_cmd mkdir -p "$config_path"
     run_login_cmd "$config_path"
-    # cnspec only falls back to the system config if it can read it
-    sudo_cmd chmod 0644 "$MONDOO_MACOS_CONFIG"
+    restrict_macos_config
   else
     config_path="$HOME/.config/mondoo"
     mkdir -p "$config_path"
     run_login_cmd "$config_path"
   fi
+}
+
+# The service config holds credentials, so it is readable for admins only.
+# cnspec falls back to it only if the user running it can read the file, and on
+# macOS everyone who can sudo is in the admin group.
+restrict_macos_config() {
+  sudo_cmd chown root:admin "$MONDOO_MACOS_CONFIG"
+  sudo_cmd chmod 0640 "$MONDOO_MACOS_CONFIG"
 }
 
 # Moves a user config from an older installer to the service config, so a
@@ -726,9 +733,12 @@ migrate_macos_config() {
   if [ ! -f "$MONDOO_MACOS_CONFIG" ]; then
     purple_bold "\n* Moving ${_user_config} to ${MONDOO_MACOS_CONFIG}"
     sudo_cmd mkdir -p "${MONDOO_MACOS_CONFIG%/*}"
-    sudo_cmd cp "$_user_config" "$MONDOO_MACOS_CONFIG"
-    sudo_cmd chmod 0644 "$MONDOO_MACOS_CONFIG"
-    sudo_cmd rm -f "$_user_config"
+    if sudo_cmd cp "$_user_config" "$MONDOO_MACOS_CONFIG"; then
+      restrict_macos_config
+      sudo_cmd rm -f "$_user_config"
+    else
+      red "\n* Could not copy ${_user_config} to ${MONDOO_MACOS_CONFIG}, keeping the existing config."
+    fi
   elif sudo_cmd cmp -s "$_user_config" "$MONDOO_MACOS_CONFIG"; then
     purple_bold "\n* Removing the duplicate config at ${_user_config}"
     sudo_cmd rm -f "$_user_config"

--- a/install.sh
+++ b/install.sh
@@ -705,46 +705,12 @@ configure_macos_token() {
   if [ "$MONDOO_SERVICE" = "enable" ]; then
     config_path="${MONDOO_MACOS_CONFIG%/*}"
     sudo_cmd mkdir -p "$config_path"
-    run_login_cmd "$config_path"
-    restrict_macos_config
   else
     config_path="$HOME/.config/mondoo"
     mkdir -p "$config_path"
-    run_login_cmd "$config_path"
-  fi
-}
-
-# The service config holds credentials, so it is readable for admins only.
-# cnspec falls back to it only if the user running it can read the file, and on
-# macOS everyone who can sudo is in the admin group.
-restrict_macos_config() {
-  sudo_cmd chown root:admin "$MONDOO_MACOS_CONFIG"
-  sudo_cmd chmod 0640 "$MONDOO_MACOS_CONFIG"
-}
-
-# Moves a user config from an older installer to the service config, so a
-# service install is not left with two configs that can drift apart.
-migrate_macos_config() {
-  _user_config="$HOME/.config/mondoo/mondoo.yml"
-  if [ ! -f "$_user_config" ]; then
-    return
   fi
 
-  if [ ! -f "$MONDOO_MACOS_CONFIG" ]; then
-    purple_bold "\n* Moving ${_user_config} to ${MONDOO_MACOS_CONFIG}"
-    sudo_cmd mkdir -p "${MONDOO_MACOS_CONFIG%/*}"
-    if sudo_cmd cp "$_user_config" "$MONDOO_MACOS_CONFIG"; then
-      restrict_macos_config
-      sudo_cmd rm -f "$_user_config"
-    else
-      red "\n* Could not copy ${_user_config} to ${MONDOO_MACOS_CONFIG}, keeping the existing config."
-    fi
-  elif sudo_cmd cmp -s "$_user_config" "$MONDOO_MACOS_CONFIG"; then
-    purple_bold "\n* Removing the duplicate config at ${_user_config}"
-    sudo_cmd rm -f "$_user_config"
-  else
-    red "\n* ${_user_config} and ${MONDOO_MACOS_CONFIG} differ. The service uses ${MONDOO_MACOS_CONFIG}, remove ${_user_config} to avoid a split configuration."
-  fi
+  run_login_cmd "$config_path"
 }
 
 configure_linux_token() {
@@ -885,10 +851,6 @@ EOL
 }
 
 finalize_setup() {
-
-  if [ "$OS" = "macOS" ] && [ "$MONDOO_SERVICE" = "enable" ]; then
-    migrate_macos_config
-  fi
 
   # Authenticate with Mondoo platform if a registration token is provided
   configure_token

--- a/packages/macos/packager/application/etc/com.mondoo.client.plist
+++ b/packages/macos/packager/application/etc/com.mondoo.client.plist
@@ -9,7 +9,7 @@
 		<string>/Library/Mondoo/bin/cnspec</string>
 		<string>serve</string>
 		<string>--config</string>
-		<string>~/.config/mondoo/mondoo.yml</string>
+		<string>/Library/Mondoo/etc/mondoo.yml</string>
 	</array>
 	<key>RunAtLoad</key>
 	<false/>

--- a/packages/macos/packager/darwin/scripts/postinstall
+++ b/packages/macos/packager/darwin/scripts/postinstall
@@ -9,6 +9,8 @@ echo "Post installation process started"
 echo "Change permissions in product home (${PRODUCT_HOME})"
 cd ${PRODUCT_HOME} || exit 1
 chmod -R 755 .
+# the config holds credentials, keep it out of reach of non-admin users
+[ -f etc/mondoo.yml ] && chmod 640 etc/mondoo.yml
 [ -d /usr/local/bin ] || mkdir /usr/local/bin
 
 #Add application shortcuts to /usr/local/bin

--- a/packages/macos/packager/darwin/scripts/postinstall
+++ b/packages/macos/packager/darwin/scripts/postinstall
@@ -9,8 +9,6 @@ echo "Post installation process started"
 echo "Change permissions in product home (${PRODUCT_HOME})"
 cd ${PRODUCT_HOME} || exit 1
 chmod -R 755 .
-# the config holds credentials, keep it out of reach of non-admin users
-[ -f etc/mondoo.yml ] && chmod 640 etc/mondoo.yml
 [ -d /usr/local/bin ] || mkdir /usr/local/bin
 
 #Add application shortcuts to /usr/local/bin

--- a/test/install_sh/test_macos_config.sh
+++ b/test/install_sh/test_macos_config.sh
@@ -54,6 +54,7 @@ login_config() {
     rm -rf "${WORK_DIR:?}/home" "${WORK_DIR:?}/system"
     purple_bold() { :; }
     sudo_cmd() { "$@"; }
+    restrict_macos_config() { :; } # needs root
     run_login_cmd() { : > "$1/mondoo.yml"; echo "$1/mondoo.yml"; }
     eval "$TOKEN_FN"
     configure_macos_token
@@ -76,6 +77,7 @@ migrate() {
     purple_bold() { :; }
     red() { :; }
     sudo_cmd() { "$@"; }
+    restrict_macos_config() { :; } # needs root
     eval "$MIGRATE_FN"
     migrate_macos_config
     printf 'user=%s system=%s\n' \

--- a/test/install_sh/test_macos_config.sh
+++ b/test/install_sh/test_macos_config.sh
@@ -2,7 +2,7 @@
 # Copyright Mondoo, Inc. 2025, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
-# Test that a macOS install keeps a single Mondoo config: service installs use
+# Test that a macOS install writes a single Mondoo config: service installs use
 # the system config only, user installs the user config (mondoohq/installer#749).
 
 # Globals and stub functions below are consumed by the eval'd install.sh functions.
@@ -39,7 +39,6 @@ extract_fn() {
 }
 
 TOKEN_FN="$(extract_fn configure_macos_token)"
-MIGRATE_FN="$(extract_fn migrate_macos_config)"
 
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
@@ -54,35 +53,11 @@ login_config() {
     rm -rf "${WORK_DIR:?}/home" "${WORK_DIR:?}/system"
     purple_bold() { :; }
     sudo_cmd() { "$@"; }
-    restrict_macos_config() { :; } # needs root
     run_login_cmd() { : > "$1/mondoo.yml"; echo "$1/mondoo.yml"; }
     eval "$TOKEN_FN"
     configure_macos_token
     [ -f "$HOME/.config/mondoo/mondoo.yml" ] && printf '+user\n'
     exit 0
-  )
-}
-
-# migrate runs migrate_macos_config over the given user/system config contents
-# ('-' means the file is absent) and prints the resulting state.
-migrate() {
-  (
-    HOME="$WORK_DIR/home"
-    MONDOO_MACOS_CONFIG="$WORK_DIR/system/mondoo.yml"
-    _user_config="$HOME/.config/mondoo/mondoo.yml"
-    rm -rf "${WORK_DIR:?}/home" "${WORK_DIR:?}/system"
-    mkdir -p "$HOME/.config/mondoo" "$WORK_DIR/system"
-    [ "$1" = '-' ] || echo "$1" > "$_user_config"
-    [ "$2" = '-' ] || echo "$2" > "$MONDOO_MACOS_CONFIG"
-    purple_bold() { :; }
-    red() { :; }
-    sudo_cmd() { "$@"; }
-    restrict_macos_config() { :; } # needs root
-    eval "$MIGRATE_FN"
-    migrate_macos_config
-    printf 'user=%s system=%s\n' \
-      "$(cat "$_user_config" 2>/dev/null || echo -)" \
-      "$(cat "$MONDOO_MACOS_CONFIG" 2>/dev/null || echo -)"
   )
 }
 
@@ -93,17 +68,6 @@ assert_equals "service install logs in to the system config" \
 assert_equals "user install logs in to the user config" \
   "$(login_config '')" "$WORK_DIR/home/.config/mondoo/mondoo.yml
 +user"
-
-assert_equals "a user config is moved to the system config" \
-  "$(migrate creds -)" "user=- system=creds"
-assert_equals "a duplicate user config is removed" \
-  "$(migrate creds creds)" "user=- system=creds"
-# Two different registrations: dropping either one could remove valid
-# credentials, so both are kept and the user is warned instead.
-assert_equals "a diverged user config is kept" \
-  "$(migrate other creds)" "user=other system=creds"
-assert_equals "no user config is a no-op" \
-  "$(migrate - creds)" "user=- system=creds"
 
 printf '\n==> Results: %d/%d passed' "$PASS" "$TESTS"
 if [ "$FAIL" -gt 0 ]; then

--- a/test/install_sh/test_macos_config.sh
+++ b/test/install_sh/test_macos_config.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# Copyright Mondoo, Inc. 2025, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Test that a macOS install keeps a single Mondoo config: service installs use
+# the system config only, user installs the user config (mondoohq/installer#749).
+
+# Globals and stub functions below are consumed by the eval'd install.sh functions.
+# shellcheck disable=SC2034,SC2317
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_SH="${SCRIPT_DIR}/../../install.sh"
+
+PASS=0
+FAIL=0
+TESTS=0
+
+assert_equals() {
+  TESTS=$((TESTS + 1))
+  _label="$1"; _got="$2"; _want="$3"
+  if [ "$_got" = "$_want" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: %s\n  expected: %s\n  got: %s\n' "$_label" "$_want" "$_got" >&2
+  fi
+}
+
+# install.sh runs on source, so the functions under test are extracted instead.
+extract_fn() {
+  _snippet="$(sed -n "/^$1()/,/^}\$/p" "$INSTALL_SH")"
+  if [ -z "$_snippet" ] || [ "$(printf '%s\n' "$_snippet" | tail -1)" != "}" ]; then
+    printf 'ERROR: could not extract %s() from %s\n' "$1" "$INSTALL_SH" >&2
+    return 1
+  fi
+  printf '%s\n' "$_snippet"
+}
+
+TOKEN_FN="$(extract_fn configure_macos_token)"
+MIGRATE_FN="$(extract_fn migrate_macos_config)"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# login_config runs configure_macos_token with a stubbed login and prints the
+# config file it would have written, plus '+user' if a user config exists.
+login_config() {
+  (
+    MONDOO_SERVICE="$1"
+    HOME="$WORK_DIR/home"
+    MONDOO_MACOS_CONFIG="$WORK_DIR/system/mondoo.yml"
+    rm -rf "${WORK_DIR:?}/home" "${WORK_DIR:?}/system"
+    purple_bold() { :; }
+    sudo_cmd() { "$@"; }
+    run_login_cmd() { : > "$1/mondoo.yml"; echo "$1/mondoo.yml"; }
+    eval "$TOKEN_FN"
+    configure_macos_token
+    [ -f "$HOME/.config/mondoo/mondoo.yml" ] && printf '+user\n'
+    exit 0
+  )
+}
+
+# migrate runs migrate_macos_config over the given user/system config contents
+# ('-' means the file is absent) and prints the resulting state.
+migrate() {
+  (
+    HOME="$WORK_DIR/home"
+    MONDOO_MACOS_CONFIG="$WORK_DIR/system/mondoo.yml"
+    _user_config="$HOME/.config/mondoo/mondoo.yml"
+    rm -rf "${WORK_DIR:?}/home" "${WORK_DIR:?}/system"
+    mkdir -p "$HOME/.config/mondoo" "$WORK_DIR/system"
+    [ "$1" = '-' ] || echo "$1" > "$_user_config"
+    [ "$2" = '-' ] || echo "$2" > "$MONDOO_MACOS_CONFIG"
+    purple_bold() { :; }
+    red() { :; }
+    sudo_cmd() { "$@"; }
+    eval "$MIGRATE_FN"
+    migrate_macos_config
+    printf 'user=%s system=%s\n' \
+      "$(cat "$_user_config" 2>/dev/null || echo -)" \
+      "$(cat "$MONDOO_MACOS_CONFIG" 2>/dev/null || echo -)"
+  )
+}
+
+printf '==> Testing macOS config handling\n\n'
+
+assert_equals "service install logs in to the system config" \
+  "$(login_config enable)" "$WORK_DIR/system/mondoo.yml"
+assert_equals "user install logs in to the user config" \
+  "$(login_config '')" "$WORK_DIR/home/.config/mondoo/mondoo.yml
++user"
+
+assert_equals "a user config is moved to the system config" \
+  "$(migrate creds -)" "user=- system=creds"
+assert_equals "a duplicate user config is removed" \
+  "$(migrate creds creds)" "user=- system=creds"
+# Two different registrations: dropping either one could remove valid
+# credentials, so both are kept and the user is warned instead.
+assert_equals "a diverged user config is kept" \
+  "$(migrate other creds)" "user=other system=creds"
+assert_equals "no user config is a no-op" \
+  "$(migrate - creds)" "user=- system=creds"
+
+printf '\n==> Results: %d/%d passed' "$PASS" "$TESTS"
+if [ "$FAIL" -gt 0 ]; then
+  printf ', %d FAILED\n' "$FAIL"
+  exit 1
+else
+  printf '\n'
+fi


### PR DESCRIPTION
Closes #749

macOS service installs logged in to `$HOME/.config/mondoo/mondoo.yml` and copied it to `/Library/Mondoo/etc/mondoo.yml`, so every asset ended up with two configs that can drift apart.

cnquery's config autodetect on darwin falls back to `/Library/Mondoo/etc/mondoo.yml` when no user config exists (verified: unprivileged `cnspec status` loads it and reports registered), so the user copy buys nothing.

- service installs log in to `/Library/Mondoo/etc/mondoo.yml` directly, no user config, no copy
- the packaged launchd plist points at the same config instead of an unexpandable `~/.config/mondoo/mondoo.yml`
- new `test/install_sh/test_macos_config.sh`, wired into the POSIX workflow

Deliberately out of scope: file permissions are left to cnspec (it writes 0644), and configs on existing installs are not migrated or removed. Machines that already have both configs keep them, and the installer no longer copies the user config over the service one. User installs (no `-s enable`) are unchanged.

Docs need a follow-up for the new config location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)