### PR TITLE
Sign the VERSION bump commit so the PR can merge

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -68,8 +68,11 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: main
-          committer: Mondoo Tools <tools@mondoo.com>
-          author: Mondoo Tools <tools@mondoo.com>
+          # main requires signed commits; without this the PR is created but
+          # merges as BLOCKED. Note that sign-commits makes the action ignore
+          # the committer/author inputs and attribute commits to the identity
+          # of the token used here (github-actions[bot]).
+          sign-commits: true
           commit-message: ${{ steps.title.outputs.COMMIT_TITLE }}
           title: ${{ steps.title.outputs.COMMIT_TITLE }}
           branch: ${{ steps.title.outputs.BRANCH_NAME }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -111,10 +111,19 @@ jobs:
           gh pr review "${PR_NUMBER}" --approve
       - name: Merge Pull Request
         if: steps.create-pr.outputs.pull-request-number
+        # Bounded so a required check that never reports fails the job (and
+        # fires the Slack alert below) rather than hanging until the job limit.
+        timeout-minutes: 20
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         run: |
+          # The merge is attempted seconds after the PR is opened, long before
+          # required checks finish, so wait for them first. --watch keeps this
+          # synchronous: unlike `gh pr merge --auto`, a failed check or refused
+          # merge fails the job instead of silently leaving the PR open.
+          echo "Waiting for checks on PR #${PR_NUMBER}"
+          gh pr checks "${PR_NUMBER}" --watch --fail-fast --interval 10
           echo "Merging PR #${PR_NUMBER}"
           gh pr merge "${PR_NUMBER}" --squash --delete-branch
       # The VERSION bump must not fail silently: main would stay out of sync


### PR DESCRIPTION
Follow-up to #751.

## What happened

Release `v13.35.1` triggered the workflow. It opened PR #753, posted the audit comment, and approved it — then `Merge Pull Request` failed:

```
X Pull request mondoohq/installer#753 is not mergeable: the base branch policy prohibits the merge.
```

## Root cause

`main` requires signed commits, and the commit on #753 was unsigned.

| PR | workflow | commit verification | outcome |
|---|---|---|---|
| #753 | `update-version.yml` | `verified: false` — `unsigned` | `BLOCKED` |
| #723 | `sign_powershell.yml` | `verified: true` — `valid` | merged |

`sign_powershell.yml:141` already sets `sign-commits: true`. That input was missed when #751 moved this workflow onto the same PR-based flow.

Nothing else was wrong with the run: both checks were green, `mergeable: MERGEABLE`, and `reviewDecision: APPROVED` by `mondoo-mergebot[bot]` on a PR authored by `github-actions[bot]`. The two-identity approval split worked as intended under a real release.

## Change

Adds `sign-commits: true`, and drops `committer:` / `author:` — [the action ignores both when signing is enabled](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md), so leaving them in would be misleading. Commits are attributed to `github-actions[bot]`, which preserves the identity split the approval depends on.

## Note on `--admin`

`gh` suggested `--admin` in the failure output. That would have force-merged an unsigned commit past a rule that exists deliberately, so it is not the right fix here — the signature requirement should be satisfied, not bypassed.

## What worked

The `if: failure()` Slack alert fired to `#mondoo-ops`. The job failed visibly at release time rather than leaving `main` quietly out of sync, which was the failure mode #751 set out to fix.

## Follow-up

PR #753 is being closed; `main` is currently still out of sync at `13.35.1`. Once this merges, a `workflow_dispatch` run with version `13.35.1` will reproduce it with a signed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)