### PR TITLE
🐛 route v13 releases to v13 branch instead of clobbering main

### DIFF
--- a/.github/scripts/determine-version-bump-base.sh
+++ b/.github/scripts/determine-version-bump-base.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Determine base branch for the installer's VERSION-file bump PR.
+#
+# When main's VERSION file has the same major as the incoming release,
+# the bump PR opens against main. Otherwise it opens against the v{major}
+# support branch (e.g. a v13.35.1 release while main tracks v14 -> v13).
+#
+# Inputs:
+#   $1 (required)   incoming release version (e.g. 13.35.1 — no leading v)
+#   $MAIN_VERSION   contents of main's VERSION file. If unset, fetched via
+#                   `gh api` using $GH_REPO (owner/repo) and $GH_TOKEN.
+#
+# Output: prints the base branch to stdout ("main" or "v{major}").
+#         Exits non-zero if main's VERSION cannot be read.
+set -euo pipefail
+
+RELEASE_VERSION="${1:?release version required as first argument}"
+
+V="${RELEASE_VERSION#v}"
+RELEASE_MAJOR="${V%%.*}"
+
+if [ -z "${MAIN_VERSION+set}" ]; then
+  # MAIN_VERSION not passed in at all — fetch it. An explicit empty value
+  # is respected (and will fail the "Could not read" check below), so tests
+  # can exercise the empty-file failure path without touching the network.
+  : "${GH_REPO:?GH_REPO or MAIN_VERSION required}"
+  MAIN_VERSION=$(gh api "/repos/${GH_REPO}/contents/VERSION?ref=main" --jq '.content' | base64 -d)
+fi
+
+# First line, trimmed of whitespace — main's VERSION should just be x.y.z
+MAIN_VERSION_TRIMMED=$(printf '%s' "$MAIN_VERSION" | head -1 | tr -d '[:space:]')
+MAIN_MAJOR="${MAIN_VERSION_TRIMMED%%.*}"
+
+if [ -z "$MAIN_MAJOR" ]; then
+  echo "Could not read main's VERSION file" >&2
+  exit 1
+fi
+
+if [ "$RELEASE_MAJOR" = "$MAIN_MAJOR" ]; then
+  echo main
+else
+  echo "v${RELEASE_MAJOR}"
+fi

--- a/.github/scripts/determine-version-bump-base.sh
+++ b/.github/scripts/determine-version-bump-base.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright Mondoo, Inc. 2025, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
 # Determine base branch for the installer's VERSION-file bump PR.
 #
 # When main's VERSION file has the same major as the incoming release,

--- a/.github/scripts/tests/determine-version-bump-base.bats
+++ b/.github/scripts/tests/determine-version-bump-base.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+# Tests for .github/scripts/determine-version-bump-base.sh
+#
+# Each test sets MAIN_VERSION in the environment so the script runs
+# without calling gh api. See the script's header for the input contract.
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../determine-version-bump-base.sh"
+}
+
+@test "matching major routes to main (v-prefixed)" {
+  MAIN_VERSION='14.0.0' run bash "$SCRIPT" v14.5.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "matching major routes to main (no v prefix)" {
+  MAIN_VERSION='14.0.0' run bash "$SCRIPT" 14.5.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "older major routes to v{major}" {
+  MAIN_VERSION='14.0.0' run bash "$SCRIPT" v13.35.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "v13" ]
+}
+
+@test "future major routes to v{major}" {
+  MAIN_VERSION='14.0.0' run bash "$SCRIPT" v15.0.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "v15" ]
+}
+
+@test "main on v13 today: v13 release routes to main" {
+  MAIN_VERSION='13.35.0' run bash "$SCRIPT" v13.35.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "trailing newline in VERSION file is ignored" {
+  MAIN_VERSION=$'14.0.0\n' run bash "$SCRIPT" v13.35.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "v13" ]
+}
+
+@test "surrounding whitespace in VERSION file is ignored" {
+  MAIN_VERSION='  14.0.0  ' run bash "$SCRIPT" v14.5.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "empty VERSION file fails loudly" {
+  MAIN_VERSION='' run bash "$SCRIPT" v13.35.1
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Could not read main's VERSION"* ]]
+}
+
+@test "missing version argument errors out" {
+  MAIN_VERSION='14.0.0' run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+}

--- a/.github/workflows/test-released-docker.yaml
+++ b/.github/workflows/test-released-docker.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ["latest", "latest-ubi-rootless", "latest-rootless"]
+        suffix: ["", "-ubi-rootless", "-rootless"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Version
@@ -34,9 +34,9 @@ jobs:
         run: |
           VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      - name: Testing mondoo/mql:${{ matrix.tag }}....
+      - name: Testing mondoo/mql:${{ steps.version.outputs.version }}${{ matrix.suffix }}....
         run: |
-          version=$(docker run --rm -v $(pwd):/work -w /work mondoo/mql:${{ matrix.tag }} version)
+          version=$(docker run --rm -v $(pwd):/work -w /work mondoo/mql:${{ steps.version.outputs.version }}${{ matrix.suffix }} version)
           echo $version
           echo $version | grep -q ${{ steps.version.outputs.version }}
   cnspec-containers:
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ["latest", "latest-ubi-rootless", "latest-rootless"]
+        suffix: ["", "-ubi-rootless", "-rootless"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Version
@@ -54,9 +54,9 @@ jobs:
         run: |
           VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      - name: Testing mondoo/cnspec:${{ matrix.tag }}....
+      - name: Testing mondoo/cnspec:${{ steps.version.outputs.version }}${{ matrix.suffix }}....
         run: |
-          version=$(docker run --rm -v $(pwd):/work -w /work mondoo/cnspec:${{ matrix.tag }} version)
+          version=$(docker run --rm -v $(pwd):/work -w /work mondoo/cnspec:${{ steps.version.outputs.version }}${{ matrix.suffix }} version)
           echo $version
           echo $version | grep -q ${{ steps.version.outputs.version }}
 
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ["latest", "latest-ubi-rootless", "latest-rootless"]
+        suffix: ["", "-ubi-rootless", "-rootless"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Version
@@ -75,8 +75,8 @@ jobs:
         run: |
           VERSION=$(echo "${INPUT_VERSION}" | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      - name: Testing mondoo/client:${{ matrix.tag }}....
+      - name: Testing mondoo/client:${{ steps.version.outputs.version }}${{ matrix.suffix }}....
         run: |
-          version=$(docker run --rm -v $(pwd):/work -w /work mondoo/client:${{ matrix.tag }} version)
+          version=$(docker run --rm -v $(pwd):/work -w /work mondoo/client:${{ steps.version.outputs.version }}${{ matrix.suffix }} version)
           echo $version
           echo $version | grep -q ${{ steps.version.outputs.version }}

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,0 +1,25 @@
+name: Test .github/scripts
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/test-scripts.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/test-scripts.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run bats tests
+        run: bats -r .github/scripts/tests

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -21,11 +21,6 @@ jobs:
       # C07R9GSGKEU == #mondoo-ops
       SLACK_BOT_CHANNEL_ID: "C07R9GSGKEU"
     steps:
-      - name: checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: 'main'
-          fetch-depth: 0
       - name: Version from Workflow Dispatch
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -46,6 +41,38 @@ jobs:
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      # Route the VERSION bump to the right branch by comparing the incoming
+      # release's major with the major currently on main (read from main's
+      # VERSION file). Matching major -> base=main; any other major -> base=
+      # v{major} support branch (e.g. a v13.35.1 release while main tracks
+      # v14 -> base=v13). Prevents a v13 patch from clobbering main's VERSION.
+      - name: Determine base branch
+        id: base
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RELEASE_MAJOR="${VERSION%%.*}"
+          MAIN_VERSION=$(gh api "/repos/${{ github.repository }}/contents/VERSION?ref=main" --jq '.content' \
+            | base64 -d \
+            | head -1 \
+            | tr -d '[:space:]')
+          MAIN_MAJOR="${MAIN_VERSION%%.*}"
+          if [ -z "$MAIN_MAJOR" ]; then
+            echo "Could not read main's VERSION file" >&2
+            exit 1
+          fi
+          if [ "$RELEASE_MAJOR" = "$MAIN_MAJOR" ]; then
+            BASE=main
+          else
+            BASE="v${RELEASE_MAJOR}"
+          fi
+          echo "Release major: ${RELEASE_MAJOR}, main major: ${MAIN_MAJOR}, base: ${BASE}"
+          echo "base=${BASE}" >> "$GITHUB_OUTPUT"
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ steps.base.outputs.base }}
+          fetch-depth: 0
       - name: Prepare title
         id: title
         run: |
@@ -67,7 +94,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          base: main
+          base: ${{ steps.base.outputs.base }}
           # main requires signed commits; without this the PR is created but
           # merges as BLOCKED. Note that sign-commits makes the action ignore
           # the committer/author inputs and attribute commits to the identity
@@ -135,7 +162,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: "${{ env.SLACK_BOT_CHANNEL_ID }}"
-            text: "VERSION bump to ${{ steps.vars.outputs.version }} did not land on main"
+            text: "VERSION bump to ${{ steps.vars.outputs.version }} did not land on ${{ steps.base.outputs.base }}"
             attachments:
               - color: "#FF0000"
                 blocks:

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -9,6 +9,10 @@ on:
         description: 'Version that should be released'
         required: true
         default: '1.2.3'
+      dry-run:
+        description: 'Skip PR create/approve/merge/slack (test base-branch decision only)'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -41,32 +45,29 @@ jobs:
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      # Sparse-checkout the scripts dir before we know the target branch, so
+      # we can run determine-version-bump-base.sh to figure out where to open
+      # the bump PR. The full checkout of the target branch happens below.
+      - name: Checkout scripts
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          sparse-checkout: '.github/scripts'
+          sparse-checkout-cone-mode: false
       # Route the VERSION bump to the right branch by comparing the incoming
       # release's major with the major currently on main (read from main's
       # VERSION file). Matching major -> base=main; any other major -> base=
       # v{major} support branch (e.g. a v13.35.1 release while main tracks
       # v14 -> base=v13). Prevents a v13 patch from clobbering main's VERSION.
+      # Logic lives in .github/scripts/determine-version-bump-base.sh and is
+      # unit-tested via .github/scripts/tests/determine-version-bump-base.bats.
       - name: Determine base branch
         id: base
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          RELEASE_MAJOR="${VERSION%%.*}"
-          MAIN_VERSION=$(gh api "/repos/${{ github.repository }}/contents/VERSION?ref=main" --jq '.content' \
-            | base64 -d \
-            | head -1 \
-            | tr -d '[:space:]')
-          MAIN_MAJOR="${MAIN_VERSION%%.*}"
-          if [ -z "$MAIN_MAJOR" ]; then
-            echo "Could not read main's VERSION file" >&2
-            exit 1
-          fi
-          if [ "$RELEASE_MAJOR" = "$MAIN_MAJOR" ]; then
-            BASE=main
-          else
-            BASE="v${RELEASE_MAJOR}"
-          fi
-          echo "Release major: ${RELEASE_MAJOR}, main major: ${MAIN_MAJOR}, base: ${BASE}"
+          BASE=$(.github/scripts/determine-version-bump-base.sh "$VERSION")
+          echo "Release: ${VERSION}, resolved base branch: ${BASE}"
           echo "base=${BASE}" >> "$GITHUB_OUTPUT"
       - name: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -82,7 +83,22 @@ jobs:
         run: |
           echo "${VERSION}" > VERSION
           echo "VERSION is ${VERSION}"
+      # Dry-run stops here after the routing/decision + local file write, so
+      # a workflow_dispatch with dry-run=true exercises the routing end to
+      # end without opening or approving a real PR.
+      - name: Dry run summary
+        if: ${{ inputs.dry-run }}
+        run: |
+          echo "::notice::DRY RUN — no PR opened."
+          echo "  version: ${VERSION}"
+          echo "  base:    ${{ steps.base.outputs.base }}"
+          echo "  branch:  ${{ steps.title.outputs.BRANCH_NAME }}"
+          echo "  title:   ${{ steps.title.outputs.COMMIT_TITLE }}"
+          echo
+          echo "Would have written this VERSION file:"
+          cat VERSION
       - name: 🔑 Generate GitHub App Token (mondoohq)
+        if: ${{ !inputs.dry-run }}
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -91,6 +107,7 @@ jobs:
           client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
           private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
       - name: Create PR
+        if: ${{ !inputs.dry-run }}
         id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -113,7 +130,7 @@ jobs:
             Opened automatically by the
             [Update Release Version workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
       - name: Add Audit Trail Comment
-        if: steps.create-pr.outputs.pull-request-number
+        if: ${{ !inputs.dry-run && steps.create-pr.outputs.pull-request-number }}
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
@@ -126,7 +143,7 @@ jobs:
           * **Audit Category:** Release Metadata Sync
           * **Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: Approve Pull Request
-        if: steps.create-pr.outputs.pull-request-number
+        if: ${{ !inputs.dry-run && steps.create-pr.outputs.pull-request-number }}
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
@@ -137,7 +154,7 @@ jobs:
           echo "Approving PR #${PR_NUMBER}"
           gh pr review "${PR_NUMBER}" --approve
       - name: Merge Pull Request
-        if: steps.create-pr.outputs.pull-request-number
+        if: ${{ !inputs.dry-run && steps.create-pr.outputs.pull-request-number }}
         # Bounded so a required check that never reports fails the job (and
         # fires the Slack alert below) rather than hanging until the job limit.
         timeout-minutes: 20
@@ -153,10 +170,10 @@ jobs:
           gh pr checks "${PR_NUMBER}" --watch --fail-fast --interval 10
           echo "Merging PR #${PR_NUMBER}"
           gh pr merge "${PR_NUMBER}" --squash --delete-branch
-      # The VERSION bump must not fail silently: main would stay out of sync
-      # with the published release with nobody watching the Actions tab.
+      # The VERSION bump must not fail silently: the target branch would stay
+      # out of sync with the published release with nobody watching Actions.
       - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-        if: failure()
+        if: ${{ failure() && !inputs.dry-run }}
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -47,10 +47,14 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       # Sparse-checkout the scripts dir before we know the target branch, so
       # we can run determine-version-bump-base.sh to figure out where to open
-      # the bump PR. The full checkout of the target branch happens below.
+      # the bump PR. Pinned to main because on the release event github.ref
+      # is the release tag (e.g. refs/tags/v13.35.1 for a v13 patch), and
+      # the v13 branch's tag may predate this script's existence. The full
+      # checkout of the resolved base branch happens below.
       - name: Checkout scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: main
           sparse-checkout: '.github/scripts'
           sparse-checkout-cone-mode: false
       # Route the VERSION bump to the right branch by comparing the incoming


### PR DESCRIPTION
## Summary

Two related workflow fixes for the model where **main tracks the current major** (soon v14) and a **v13 support branch** keeps shipping patches.

### `update-version.yml`

`checkout ref: main` and `Create PR base: main` were hardcoded. Once main is on v14, a v13.35.1 release would check out v14 code, write `13.35.1` to `VERSION`, and open a PR that either fights v14 or demotes it.

The base decision now lives in `.github/scripts/determine-version-bump-base.sh`. It reads main's `VERSION` file (via `gh api`) to learn its major, then:
- `release_major == main_major` → `base=main`
- `release_major != main_major` → `base=v{major}` (e.g. `v13`)

Both the checkout `ref` and the `Create PR` `base` derive from it. Slack failure message references the actual base instead of hardcoded `main`.

### `test-released-docker.yaml`

Matrix was hardcoded `["latest", "latest-ubi-rootless", "latest-rootless"]`. Once `:latest` is gated to the current shipping major (separate, upcoming PR against `.goreleaser.yml`), a v13 patch test run would pull v14 images and fail. Matrix now iterates over tag **suffixes** and constructs the pull tag as `${version}${suffix}`, testing the actual version-tagged images.

## Testability

- **`bats` unit tests** in `.github/scripts/tests/determine-version-bump-base.bats` — 9 cases covering matching/mismatched majors, v-prefixed and bare versions, both v13-on-main and v14-on-main worlds, trailing newline/whitespace handling, and the empty-VERSION failure path. Runs in CI via the new `test-scripts.yml` workflow on any PR that touches `.github/scripts/**`.
- **`workflow_dispatch` dry-run** on `update-version.yml`: `dry-run=true` runs the routing, checks out the resolved base, writes the VERSION file locally, and prints a summary — but skips PR create / approve / merge / slack.

### Test recipes

Run bats tests locally:
```
bats -r .github/scripts/tests
```

Dry-run dispatch on this PR branch:
```
gh workflow run update-version.yml -R mondoohq/installer \
  --ref philip/route-v13-releases-by-major \
  -f version=13.35.99 -f dry-run=true
# expect: base=main (today, while main is on v13)

gh workflow run update-version.yml -R mondoohq/installer \
  --ref philip/route-v13-releases-by-major \
  -f version=14.0.0 -f dry-run=true
# expect: base=v14 (branch doesn't exist yet, so the "checkout" step
# after the base decision fails visibly — correct failure mode)
```

For `test-released-docker.yaml`, dispatch with a known-good version to prove the version-suffixed tags exist:
```
gh workflow run test-released-docker.yaml -R mondoohq/installer \
  --ref philip/route-v13-releases-by-major \
  -f version=13.35.0
# expects the workflow to test mondoo/{mql,cnspec,client}:13.35.0,
# 13.35.0-ubi-rootless, 13.35.0-rootless.
# Note: assumes goreleaser publishes version-suffixed manifests; verify
# by checking `docker manifest inspect mondoo/cnspec:13.35.0-ubi-rootless`
# before merging.
```

## Motivation
Prereq for cutting a `v13` support branch on installer while main tracks v14.

## Follow-up
The docker `:latest` gate itself (in cnspec/mql `.goreleaser.yml`) is a separate, larger PR that needs its own discussion — the container-registry twin of the `make_latest` fix in installer PR #752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
